### PR TITLE
Fix help comment and method of printing inst for curl

### DIFF
--- a/src/scripts/linuxInstallCpu.sh
+++ b/src/scripts/linuxInstallCpu.sh
@@ -13,7 +13,26 @@
 ## ターミナルでインストールを実行する
 # 1. ターミナルを起動する
 # 2. 次のように入力して実行する
-#    bash [ファイル名].sh
+#    chmod +x [ファイル名].sh
+#    ./[ファイル名].sh
+
+if ! command -v curl &> /dev/null; then
+    cat << 'EOS'
+* curl コマンドが見つかりません。
+
+以下のコマンドを実行してください。
+
+Ubuntu/Debian:
+    sudo apt install curl
+
+CentOS/Fedora:
+    sudo dnf install curl
+もしくは
+    sudo yum install curl
+EOS
+    sleep 365d
+    exit 1
+fi
 
 curl -fsSL https://raw.githubusercontent.com/Hiroshiba/voicevox/main/build/installer_linux.sh |
     VERSION=0.7.5 NAME=linux-cpu-appimage bash

--- a/src/scripts/linuxInstallNvidia.sh
+++ b/src/scripts/linuxInstallNvidia.sh
@@ -13,7 +13,26 @@
 ## ターミナルでインストールを実行する
 # 1. ターミナルを起動する
 # 2. 次のように入力して実行する
-#    bash [ファイル名].sh
+#    chmod +x [ファイル名].sh
+#    ./[ファイル名].sh
+
+if ! command -v curl &> /dev/null; then
+    cat << 'EOS'
+* curl コマンドが見つかりません。
+
+以下のコマンドを実行してください。
+
+Ubuntu/Debian:
+    sudo apt install curl
+
+CentOS/Fedora:
+    sudo dnf install curl
+もしくは
+    sudo yum install curl
+EOS
+    sleep 365d
+    exit 1
+fi
 
 curl -fsSL https://raw.githubusercontent.com/Hiroshiba/voicevox/main/build/installer_linux.sh |
     VERSION=0.7.5 bash


### PR DESCRIPTION
HPからダウンロードしたスクリプト
<https://voicevox.hiroshiba.jp/static/65caa0be13f5ede5ebe31318c4d42c71/linuxInstallCpu.sh>
を見て、コメントに書いてある実行方法の改善と、複数行のcurlインストール方法の`echo`をheredocに書き換えました。