### PR TITLE
Web Font Loader を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
-    "sass": "^1.36.0"
+    "sass": "^1.36.0",
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@types/gtag.js": "0.0.7",

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,5 +1,6 @@
 import * as React from "react"
 import PropTypes from "prop-types"
+import WebFont from "webfontloader"
 
 import "./layout.scss"
 
@@ -10,5 +11,17 @@ const Layout = ({ children }) => {
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
 }
+
+WebFont.load({
+  google: {
+    families: ['M PLUS Rounded 1c']
+  },
+  loading: function () {
+    document.documentElement.style.visibility = 'hidden';
+  },
+  active: function () {
+    document.documentElement.style.visibility = 'visible';
+  }
+});
 
 export default Layout

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -18,6 +18,9 @@ WebFont.load({
   },
   loading: function () {
     document.documentElement.style.visibility = 'hidden';
+    setTimeout(() => {
+        document.documentElement.style.visibility = 'visible'
+      }, 1000);
   },
   active: function () {
     document.documentElement.style.visibility = 'visible';

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -1,8 +1,11 @@
 @import "~bulma/sass/utilities/initial-variables";
 
 $primary: #a5d4adff;
-
-@import url("https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@300;400;500;700&display=swap");
+$font-smoothing: subpixel-antialiased;
+$text-rendering: optimizeLegibility;
+@media only screen and (-webkit-min-device-pixel-ratio: 2),(min-resolution: 2dppx) {
+  $font-smoothing: antialiased;
+}
 $family-sans-serif: "M PLUS Rounded 1c", sans-serif;
 
 $dropdown-item-active-color: hsl(0, 0%, 4%);


### PR DESCRIPTION
### 内容
https://github.com/typekit/webfontloader でフォント読み込み時にHtmlを表示させないようにする

ref https://github.com/VOICEVOX/voicevox_blog/issues/5#issuecomment-1001432242
