### PR TITLE
セキュリティ関係の<meta>を追加

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -30,6 +30,22 @@ function Seo({ description, lang, meta, title, image }) {
       titleTemplate={null}
       meta={[
         {
+          name: "http-equiv='Content-Security-Policy'",
+          content: "default-src 'self'",
+        },
+        {
+          name: "http-equiv='Content-Security-Policy'",
+          content: "upgrade-insecure-requests",
+        },
+        {
+          name: "http-equiv='Permissions-Policy'",
+          content: "interest-cohort=()",
+        },
+        {
+          name: "http-equiv='X-FRAME-OPTIONS'",
+          content: "DENY",
+        },
+        {
           name: `description`,
           content: metaDescription,
         },


### PR DESCRIPTION
セキュリティ関係の<meta>を追加します。
seo.js に書いてしまったのですが、大丈夫でしょうか。

タグはそれぞれ
Cross Site Scripting (XSS) や data injection 攻撃を防ごうという気持ちを表明します。
HTTP経由で提供されるURL をセキュリティで保護されたHTTPSを介して提供されるものに置き換えられたかのように処理するよう指示します。
セキュリティとは関係ないですが、サーバをFLoCの分析対象から外します。
クリックジャッキング攻撃の対策をします。

セキュリティ的にはあまり意味はないですが、SEO対策には良いと思います。