### PR TITLE
GPU linuxインストール時にNAMEを指定する

### DIFF
--- a/src/scripts/linuxInstallNvidia.sh
+++ b/src/scripts/linuxInstallNvidia.sh
@@ -37,5 +37,5 @@ EOS
 fi
 
 curl -fsSL https://raw.githubusercontent.com/VOICEVOX/voicevox/0.9.4/build/installer_linux.sh >tmp_voicevox_installer.sh
-VERSION=0.9.4 bash tmp_voicevox_installer.sh
+VERSION=0.9.4 NAME=linux-nvidia-appimage bash tmp_voicevox_installer.sh
 rm tmp_voicevox_installer.sh


### PR DESCRIPTION
GPU版linux VOICEVOXをインストールするとき、環境変数にNAMEが定義済みだと挙動がおかしくなるので修正

- https://github.com/VOICEVOX/voicevox/issues/635