### PR TITLE
`downloadUrls`の型の修正

### DIFF
--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -38,13 +38,12 @@ export const DownloadModal: React.FC<{
       }
     `).allFile.nodes
 
-  // FIXME: 型エラーが出る
   const downloadUrls: Record<
     OsType,
-    Record<
+    Partial<Record<
       ModeType,
-      Record<PackageType, { url: string; name: string } | undefined> | undefined
-    >
+      Partial<Record<PackageType, { url: string; name: string }>>
+    >>
   > = {
     Windows: {
       "GPU / CPU": {


### PR DESCRIPTION
# 内容
`downloadUrls`が
```typescript
Record<
  OsType,
  Record<
    ModeType,
    Record<
      PackageType,
      { url: string; name: string }
    >
  >
>
```
だったのを
```typescript
Record<
  OsType,
  Partial<Record<
    ModeType,
    Partial<Record<
      PackageType,
      { url: string; name: string }
    >>
  >>
>
```
に変更し，型エラーを修正しました．

