### PR TITLE
スマホでスタイルが変更できない問題の修正

### DIFF
--- a/src/components/audioSample.tsx
+++ b/src/components/audioSample.tsx
@@ -44,8 +44,6 @@ export default ({
               className={`dropdown ${isOpenDropdown ? "is-active" : ""}`}
               onMouseEnter={() => setIsOpenDropdown(true)}
               onMouseLeave={() => setIsOpenDropdown(false)}
-              onFocus={() => setIsOpenDropdown(true)}
-              onBlur={() => setIsOpenDropdown(false)}
             >
               <div className="dropdown-trigger">
                 <button
@@ -53,6 +51,8 @@ export default ({
                   aria-haspopup="true"
                   aria-controls="dropdown-menu"
                   type="button"
+                  onFocus={() => setIsOpenDropdown(true)}
+                  onBlur={() => setIsOpenDropdown(false)}
                 >
                   <span>{selectedStyle}</span>
                   <span className="icon">
@@ -68,11 +68,7 @@ export default ({
                       className={`dropdown-item is-primary ${
                         style == selectedStyle ? "is-active" : ""
                       }`}
-                      onClick={() => {
-                        setSelectedStyle(style)
-                        setIsOpenDropdown(false)
-                      }}
-                      onFocus={() => {
+                      onMouseDown={() => {
                         setSelectedStyle(style)
                         setIsOpenDropdown(false)
                       }}


### PR DESCRIPTION
HTMLのイベントに関する知識が足りてませんでした。

スタイル一覧ボタンをクリックしてもスタイルメニューが開かない
→　onFocusがボタンではなかったから（だと思います）

スタイルをクリックしてもスタイルが変わらない
→　onClickはonBlurの後に呼ばれるから

close #93
