### PR TITLE
製品ページでの画像見切れが起きにくくする

### DIFF
--- a/src/components/dormitoryCharacterModal.tsx
+++ b/src/components/dormitoryCharacterModal.tsx
@@ -146,7 +146,6 @@ export default ({
               <GatsbyImage
                 image={characterInfo.portraitImage}
                 alt={characterInfo.name}
-                imgStyle={{ height: "100%", width: "100%" }}
                 style={{ height: "100%", width: "100%" }}
               />
             </div>

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -165,11 +165,14 @@ $dropdown-item-active-background-color: $primary;
     height: calc(100vh - 3.25rem);
     display: flex;
     flex-direction: row-reverse;
+    min-height: calc($desktop / 2);
+    max-height: $desktop;
 
     position: relative;
 
     @include mobile {
       height: auto;
+      max-height: unset;
       flex-direction: column;
       gap: 3rem;
     }
@@ -195,7 +198,10 @@ $dropdown-item-active-background-color: $primary;
       flex: 0 1 50%;
 
       @include mobile {
+        flex: 0 1 auto;
+        height: calc(100vh - 3.25rem);
         min-height: calc(100vh - 3.25rem);
+        max-height: calc(100vh - 3.25rem);
       }
 
       &::before {
@@ -214,6 +220,7 @@ $dropdown-item-active-background-color: $primary;
       }
 
       .image-wrapper {
+        height: 100%;
         position: absolute;
         top: 0;
         bottom: 0;
@@ -221,8 +228,13 @@ $dropdown-item-active-background-color: $primary;
         right: 0;
         transform: translateX(-5%);
 
-        display: flex;
-        justify-content: center;
+        img {
+          object-fit: cover !important;
+          // 画像は1:1に加工されている
+          @media (min-aspect-ratio: 1/1) and (not (min-width: $tablet)) {
+            object-fit: contain !important;
+          }
+        }
       }
       .image-wrapper.entering-right {
         animation: entering-right 0.15s ease-out;
@@ -363,7 +375,9 @@ $dropdown-item-active-background-color: $primary;
 
       .thumb {
         width: 50%;
-        border: 1.5px solid;
+        img {
+          border: 1.5px solid;
+        }
         @extend .ml-6;
         @include mobile {
           width: 100%;
@@ -569,14 +583,21 @@ $dropdown-item-active-background-color: $primary;
         @extend .py-1;
         @extend .px-0;
 
+        // 大きい画面では左側にいっぱい画像表示
         @include tablet {
           border-right: solid;
+          img {
+            object-fit: cover !important;
+          }
         }
-
-        img {
-          object-fit: cover !important;
-          @include mobile {
-            object-fit: contain !important;
+        // スマホ画面ではファーストビューに画像を表示
+        @include mobile {
+          height: 100vh;
+          img {
+            // 画像は1:1に加工されている
+            @media (min-aspect-ratio: 1/1) {
+              object-fit: contain !important;
+            }
           }
         }
       }

--- a/src/hooks/useDetailedCharacterInfo.ts
+++ b/src/hooks/useDetailedCharacterInfo.ts
@@ -9,15 +9,21 @@ import { useCharacterInfo } from "./useCharacterInfo"
 export const useDetailedCharacterInfo = () => {
   const query: Queries.DetailedCharacterInfoQuery = useStaticQuery(graphql`
     query DetailedCharacterInfo {
-      portrait: allFile(filter: { absolutePath: { regex: "/portrait/" } }) {
+      portrait: allFile(filter: { relativePath: { regex: "/portrait/" } }) {
         nodes {
           name
           childImageSharp {
-            gatsbyImageData(height: 640)
+            gatsbyImageData(
+              layout: FULL_WIDTH
+              height: 1280
+              aspectRatio: 1
+              transformOptions: { fit: CONTAIN }
+              backgroundColor: "#0000"
+            )
           }
         }
       }
-      bustup: allFile(filter: { absolutePath: { regex: "/bustup/" } }) {
+      bustup: allFile(filter: { relativePath: { regex: "/bustup/" } }) {
         nodes {
           name
           childImageSharp320px: childImageSharp {
@@ -31,7 +37,7 @@ export const useDetailedCharacterInfo = () => {
       dormitoryImage: allFile(
         filter: {
           sourceInstanceName: { regex: "/image/" }
-          absolutePath: { regex: "/dormitory/" }
+          relativePath: { regex: "/dormitory/" }
         }
       ) {
         nodes {
@@ -63,7 +69,7 @@ export const useDetailedCharacterInfo = () => {
           publicURL
         }
       }
-      ogp: allFile(filter: { absolutePath: { regex: "/bustup/" } }) {
+      ogp: allFile(filter: { relativePath: { regex: "/bustup/" } }) {
         nodes {
           name
           childImageSharp {

--- a/src/pages/product/{Character.characterId}.tsx
+++ b/src/pages/product/{Character.characterId}.tsx
@@ -245,13 +245,7 @@ const ProductPage = ({ params }: PageProps) => {
                       <GatsbyImage
                         image={characterInfos[obj.characterKey]!.portraitImage}
                         alt={characterInfos[obj.characterKey]!.name}
-                        objectFit="cover"
-                        imgStyle={{ height: "100%", width: "auto" }}
-                        style={{
-                          height: "100%",
-                          width: "auto",
-                          flex: "0 0 auto",
-                        }}
+                        style={{ width: "100%", height: "100%" }}
                       />
                     </div>
                   )


### PR DESCRIPTION
「縦幅を揃えつつ画像を極力大きく表示し、中央に表示するのを任意の縦横比で行う」というのがGatsbyImageでできなかった･･･。
代わりに立ち絵を全てアスペクト比１にし、表示領域がせいほうけいくらいになるかならないかあたりでobject-fitを切り替えるようにした。

もしどうしてもGatsbyImageがサポートしていない表示形式を実現したいなら、GatsbyImageの全スタイルを消すところから始めたほうが良さそう。
（かなり特殊なことをしていました。）

なにもしないimgを召喚できるようなラッパーを書いても良いかもしれない。