### PR TITLE
Add: ボイボ寮キャラクターの呼称表

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -866,7 +866,7 @@ $dropdown-item-active-background-color: $primary;
 
   th,
   td {
-    height: 60px;
+    height: 80px;
     width: 150px;
     padding: 5px;
 
@@ -877,6 +877,10 @@ $dropdown-item-active-background-color: $primary;
 
     vertical-align: middle;
     border: none;
+  }
+
+  // はみ出すときは省略して表示, ホバーで全文表示
+  td p {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -893,7 +897,11 @@ $dropdown-item-active-background-color: $primary;
       background: white;
       border-bottom: 1px solid gray;
 
-      &:first-child {
+      &.you {
+        border-right: 1px solid gray;
+      }
+
+      &.origin {
         width: 180px;
         z-index: 1;
         border-right: 1px solid gray;
@@ -902,28 +910,30 @@ $dropdown-item-active-background-color: $primary;
   }
 
   tbody tr {
-    th {
-      &:first-child {
-        display: flex;
-        width: 180px;
-        gap: 20px;
-        text-align: center;
-        justify-content: flex-start;
-        align-items: center;
-        border-right: 1px solid gray;
+    td.you {
+      border-right: 1px solid gray;
+    }
 
-        // キャラクター名
-        p {
-          width: calc(180px - 50px);
-          white-space: normal;
-          text-align: left;
-          justify-content: flex-end;
-        }
+    th {
+      display: flex;
+      width: 180px;
+      gap: 20px;
+      text-align: center;
+      justify-content: flex-start;
+      align-items: center;
+      border-right: 1px solid gray;
+
+      // キャラクター名
+      p {
+        width: calc(180px - 50px);
+        white-space: normal;
+        text-align: left;
+        justify-content: flex-end;
       }
     }
 
     td {
-      .same,
+      .me,
       .unknown {
         color: gray;
       }
@@ -931,9 +941,9 @@ $dropdown-item-active-background-color: $primary;
   }
 
   .origin {
-    padding: 5px 0 0 5px;
+    padding: 0;
 
-    span {
+    p {
       font-weight: normal;
 
       &:nth-child(1) {

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -841,3 +841,82 @@ $dropdown-item-active-background-color: $primary;
     opacity: 1;
   }
 }
+
+// キャラの呼称表
+.call-name {
+  height: 90vh;
+  width: auto;
+  margin: 20px;
+  overflow-y: auto;
+
+  table {
+    width: 100%;
+    padding: 0;
+    margin: 0 auto;
+    border-collapse: separate;
+    table-layout: fixed;
+    border: none;
+  }
+
+  th,
+  td {
+    height: 60px;
+    width: 150px;
+    padding: 5px;
+
+    // FIXME:
+    // `table td:not([align]), table th:not([align])` で
+    // text-align: inherit になっている
+    text-align: center !important;
+    vertical-align: middle;
+    border: none;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    left: 0;
+  }
+
+  thead tr th {
+    background: white;
+    border-bottom: 1px solid gray;
+
+    &:first-child {
+      width: 180px;
+      z-index: 1;
+      border-right: 1px solid gray;
+    }
+  }
+
+  tbody tr {
+    th {
+      &:first-child {
+        display: flex;
+        width: 180px;
+        gap: 20px;
+        text-align: center;
+        justify-content: flex-start;
+        border-right: 1px solid gray;
+      }
+    }
+
+    td {
+      .unknown {
+        color: gray;
+        font-style: italic;
+      }
+
+      &:empty {
+        // workaround: 斜線の描画
+        background: linear-gradient(
+          to right top,
+          transparent calc(50% - 0.5px),
+          gray 50%,
+          gray calc(50% + 0.5px),
+          transparent calc(50% + 1px)
+        );
+      }
+    }
+  }
+}

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -844,9 +844,9 @@ $dropdown-item-active-background-color: $primary;
 
 // キャラの呼称表
 .call-name {
-  height: 90vh;
+  height: 85vh;
   width: auto;
-  margin: 20px;
+  margin: 0 20px;
   overflow-y: auto;
 
   table {
@@ -858,6 +858,12 @@ $dropdown-item-active-background-color: $primary;
     border: none;
   }
 
+  th {
+    position: sticky;
+    top: 0;
+    left: 0;
+  }
+
   th,
   td {
     height: 60px;
@@ -865,27 +871,33 @@ $dropdown-item-active-background-color: $primary;
     padding: 5px;
 
     // FIXME:
-    // `table td:not([align]), table th:not([align])` で
+    // `table td:not([align]), table th:not([align])`セレクター によって
     // text-align: inherit になっている
     text-align: center !important;
+
     vertical-align: middle;
     border: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:hover {
+      overflow: auto;
+      white-space: normal;
+      text-overflow: initial;
+    }
   }
 
-  th {
-    position: sticky;
-    top: 0;
-    left: 0;
-  }
+  thead tr {
+    th {
+      background: white;
+      border-bottom: 1px solid gray;
 
-  thead tr th {
-    background: white;
-    border-bottom: 1px solid gray;
-
-    &:first-child {
-      width: 180px;
-      z-index: 1;
-      border-right: 1px solid gray;
+      &:first-child {
+        width: 180px;
+        z-index: 1;
+        border-right: 1px solid gray;
+      }
     }
   }
 
@@ -897,26 +909,58 @@ $dropdown-item-active-background-color: $primary;
         gap: 20px;
         text-align: center;
         justify-content: flex-start;
+        align-items: center;
         border-right: 1px solid gray;
+
+        // キャラクター名
+        p {
+          width: calc(180px - 50px);
+          white-space: normal;
+          text-align: left;
+          justify-content: flex-end;
+        }
       }
     }
 
     td {
+      .same,
       .unknown {
         color: gray;
-        font-style: italic;
       }
+    }
+  }
 
-      &:empty {
-        // workaround: 斜線の描画
-        background: linear-gradient(
-          to right top,
-          transparent calc(50% - 0.5px),
-          gray 50%,
-          gray calc(50% + 0.5px),
-          transparent calc(50% + 1px)
-        );
+  .origin {
+    padding: 5px 0 0 5px;
+
+    span {
+      font-weight: normal;
+
+      &:nth-child(1) {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        padding: 10px;
       }
+      &:nth-child(2) {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 10px;
+      }
+    }
+
+    div {
+      height: 100%;
+      width: 100%;
+      // workaround: 斜線の描画
+      background: linear-gradient(
+        to right top,
+        transparent calc(50% - 0.5px),
+        gray 50%,
+        gray calc(50% + 0.5px),
+        transparent calc(50% + 1px)
+      );
     }
   }
 }

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -842,6 +842,11 @@ $dropdown-item-active-background-color: $primary;
   }
 }
 
+$call-name-border: 1px solid gray;
+$call-name-cell-height: 80px;
+$call-name-cell-width: 150px;
+$call-name-cell-width-column: 180px;
+
 // キャラの呼称表
 .call-name {
   height: 85vh;
@@ -866,8 +871,8 @@ $dropdown-item-active-background-color: $primary;
 
   th,
   td {
-    height: 80px;
-    width: 150px;
+    height: $call-name-cell-height;
+    width: $call-name-cell-width;
     padding: 5px;
 
     // FIXME:
@@ -880,7 +885,7 @@ $dropdown-item-active-background-color: $primary;
   }
 
   // はみ出すときは省略して表示, ホバーで全文表示
-  td p {
+  td > p {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -892,50 +897,80 @@ $dropdown-item-active-background-color: $primary;
     }
   }
 
-  thead tr {
+  thead > tr {
     th {
       background: white;
-      border-bottom: 1px solid gray;
+      border-bottom: $call-name-border;
 
       &.you {
-        border-right: 1px solid gray;
+        border-right: $call-name-border;
       }
 
       &.origin {
-        width: 180px;
+        width: $call-name-cell-width-column;
         z-index: 1;
-        border-right: 1px solid gray;
+        border-right: $call-name-border;
+      }
+
+      @include mobile {
+        &.origin {
+          width: 100px;
+        }
       }
     }
   }
 
-  tbody tr {
-    td.you {
-      border-right: 1px solid gray;
-    }
-
+  tbody > tr {
     th {
-      display: flex;
-      width: 180px;
-      gap: 20px;
-      text-align: center;
-      justify-content: flex-start;
-      align-items: center;
-      border-right: 1px solid gray;
+      border-right: $call-name-border;
+      width: $call-name-cell-width-column;
 
-      // キャラクター名
-      p {
-        width: calc(180px - 50px);
-        white-space: normal;
-        text-align: left;
-        justify-content: flex-end;
+      a {
+        display: flex;
+        gap: 20px;
+        text-align: center;
+        justify-content: flex-start;
+        align-items: center;
+        cursor: pointer;
+
+        // キャラクター名
+        p {
+          width: calc($call-name-cell-width-column - 50px);
+          white-space: normal;
+          text-align: left;
+          justify-content: flex-end;
+        }
+      }
+
+      @include mobile {
+        width: 100px;
+
+        a {
+          justify-content: center;
+          p {
+            display: none;
+          }
+        }
       }
     }
 
     td {
-      .me,
-      .unknown {
-        color: gray;
+      &.you {
+        border-right: $call-name-border;
+      }
+
+      p {
+        user-select: all;
+
+        &.me,
+        &.unknown {
+          color: gray;
+
+          &.unknown {
+            user-select: none;
+            cursor: not-allowed;
+          }
+        }
       }
     }
   }

--- a/src/pages/call-name/index.tsx
+++ b/src/pages/call-name/index.tsx
@@ -27,7 +27,6 @@ function rgba2rgbOnWhite(
 export default function CallNamePage() {
   const { characterInfos, callNameInfos } = useDetailedCharacterInfo()
   const { characterKeys } = useContext(CharacterContext)
-  console.log(characterInfos, characterKeys)
 
   function getCharacterImage(characterKey: CharacterKey): ReactElement {
     const characterInfo = characterInfos[characterKey]
@@ -47,44 +46,28 @@ export default function CallNamePage() {
   }
 
   function getColumn(characterKey: CharacterKey): ReactElement[] {
+    const callNameInfo = callNameInfos[characterKey]
+
     return characterKeys.map(_characterKey => {
-      const characterInfo = characterInfos[_characterKey]
-      const callNameInfo = callNameInfos[characterKey]
-
       const callName = callNameInfo[_characterKey]
-      const callNameSplit = callName ? callName.split("/") : []
-
-      if (characterKey === _characterKey) {
-        return (
-          <td key={_characterKey}>
-            <span className="same">
-              {callNameInfo.me.map((part, index) => (
-                <span key={index}>
-                  {part}
-                  {index !== callNameSplit.length - 1 ? <br /> : ""}
-                </span>
-              ))}
-            </span>
-          </td>
-        )
-      }
-
-      if (callName == undefined) {
-        return (
-          <td key={_characterKey}>
-            <span className="unknown">?</span>
-          </td>
-        )
-      }
 
       return (
         <td key={_characterKey}>
-          {callNameSplit.map((part, index) => (
-            <span key={index}>
-              {part}
-              {index !== callNameSplit.length - 1 ? <br /> : ""}
-            </span>
-          ))}
+          {(() => {
+            if (characterKey === _characterKey) {
+              return callNameInfo.me.map(part => (
+                <p key={part} className="me">
+                  {part}
+                </p>
+              ))
+            }
+
+            if (callName == undefined) {
+              return <p className="unknown">?</p>
+            }
+
+            return callName.split("/").map(part => <p key={part}>{part}</p>)
+          })()}
         </td>
       )
     })
@@ -102,9 +85,13 @@ export default function CallNamePage() {
         <table border={1}>
           <thead>
             <tr>
+              <th className="you">
+                <p>全員</p>
+                <p>(二人称)</p>
+              </th>
               <th className="origin">
-                <span>誰が</span>
-                <span>誰を</span>
+                <p>誰が</p>
+                <p>誰を</p>
                 <div />
               </th>
               {characterKeys.map(characterKey => {
@@ -112,8 +99,7 @@ export default function CallNamePage() {
                 return (
                   <th key={characterKey}>
                     {getCharacterImage(characterKey)}
-                    <br />
-                    {characterInfo.name}
+                    <p>{characterInfo.name}</p>
                   </th>
                 )
               })}
@@ -122,6 +108,7 @@ export default function CallNamePage() {
           <tbody>
             {characterKeys.map(characterKey => {
               const characterInfo = characterInfos[characterKey]
+              const callNameInfo = callNameInfos[characterKey]
 
               // 色を半透明するとセルが重なったとき, スクロール時にセルが
               // 透けて見えてしまうので, 白地での RGB に変換する
@@ -132,6 +119,11 @@ export default function CallNamePage() {
 
               return (
                 <tr key={characterKey} style={{ backgroundColor }}>
+                  <td className="you">
+                    {callNameInfo.you.map(callName => (
+                      <p>{callName}</p>
+                    ))}
+                  </td>
                   <th style={{ backgroundColor }}>
                     {getCharacterImage(characterKey)}
                     <p>{characterInfo.name}</p>

--- a/src/pages/call-name/index.tsx
+++ b/src/pages/call-name/index.tsx
@@ -12,7 +12,7 @@ function hex2rgba(hex: string, alpha = 1): [number, number, number, number] {
   return [red, green, blue, alpha]
 }
 
-function rgba2rgb(
+function rgba2rgbOnWhite(
   red: number,
   green: number,
   blue: number,
@@ -35,9 +35,10 @@ export default function CallNamePage() {
       <GatsbyImage
         image={characterInfo.bustupImage}
         alt={characterInfo.name}
+        imgStyle={{ width: "50px" }}
         style={{
           borderColor: characterInfo.color,
-          height: "50px",
+          width: "50px",
           aspectRatio: "1/1",
         }}
         objectFit="contain"
@@ -53,20 +54,37 @@ export default function CallNamePage() {
       const callName = callNameInfo[_characterKey]
       const callNameSplit = callName ? callName.split("/") : []
 
-      if (characterKey === _characterKey) return <td key={_characterKey} />
+      if (characterKey === _characterKey) {
+        return (
+          <td key={_characterKey}>
+            <span className="same">
+              {callNameInfo.me.map((part, index) => (
+                <span key={index}>
+                  {part}
+                  {index !== callNameSplit.length - 1 ? <br /> : ""}
+                </span>
+              ))}
+            </span>
+          </td>
+        )
+      }
+
+      if (callName == undefined) {
+        return (
+          <td key={_characterKey}>
+            <span className="unknown">?</span>
+          </td>
+        )
+      }
 
       return (
         <td key={_characterKey}>
-          {callName ? (
-            callNameSplit.map((part, index) => (
-              <span key={index}>
-                {part}
-                {index !== callNameSplit.length - 1 ? <br /> : ""}
-              </span>
-            ))
-          ) : (
-            <span className="unknown">?</span>
-          )}
+          {callNameSplit.map((part, index) => (
+            <span key={index}>
+              {part}
+              {index !== callNameSplit.length - 1 ? <br /> : ""}
+            </span>
+          ))}
         </td>
       )
     })
@@ -74,11 +92,21 @@ export default function CallNamePage() {
 
   return (
     <Page>
+      <section style={{ padding: "20px" }}>
+        <h1 className="title">キャラクターの呼称表</h1>
+        <p>
+          ボイボ寮のキャラクターの呼び方一覧表です。必ずしも遵守する必要はなく、自由に改変して頂いても問題ありません。
+        </p>
+      </section>
       <div className="call-name">
         <table border={1}>
           <thead>
             <tr>
-              <th className="origin"></th>
+              <th className="origin">
+                <span>誰が</span>
+                <span>誰を</span>
+                <div />
+              </th>
               {characterKeys.map(characterKey => {
                 const characterInfo = characterInfos[characterKey]
                 return (
@@ -94,28 +122,19 @@ export default function CallNamePage() {
           <tbody>
             {characterKeys.map(characterKey => {
               const characterInfo = characterInfos[characterKey]
-              const [_red, _green, _blue, _alpha] = hex2rgba(
-                characterInfo.lightColor,
-                0.5
-              )
-              const [red, green, blue] = rgba2rgb(_red, _green, _blue, _alpha)
 
-              console.log([_red, _green, _blue, _alpha], [red, green, blue])
+              // 色を半透明するとセルが重なったとき, スクロール時にセルが
+              // 透けて見えてしまうので, 白地での RGB に変換する
+              const [red, green, blue] = rgba2rgbOnWhite(
+                ...hex2rgba(characterInfo.lightColor, 0.5)
+              )
+              const backgroundColor = `rgb(${red}, ${green}, ${blue})`
 
               return (
-                <tr
-                  key={characterKey}
-                  style={{
-                    background: `rgb(${red}, ${green}, ${blue})`,
-                  }}
-                >
-                  <th
-                    style={{
-                      background: `rgb(${red}, ${green}, ${blue})`,
-                    }}
-                  >
+                <tr key={characterKey} style={{ backgroundColor }}>
+                  <th style={{ backgroundColor }}>
                     {getCharacterImage(characterKey)}
-                    {characterInfo.name}
+                    <p>{characterInfo.name}</p>
                   </th>
                   {getColumn(characterKey)}
                 </tr>

--- a/src/pages/call-name/index.tsx
+++ b/src/pages/call-name/index.tsx
@@ -1,0 +1,108 @@
+import { Page } from "../../components/page"
+import React, { ReactElement, useContext } from "react"
+import { useDetailedCharacterInfo } from "../../hooks/useDetailedCharacterInfo"
+import { CharacterContext } from "../../contexts/context"
+import { CharacterKey } from "../../types/dormitoryCharacter"
+
+const hex2rgba = (hex: string, alpha = 1) => {
+  const match = hex.match(/\w\w/g)
+
+  if (!match) throw new Error("Invalid hex")
+
+  const [r, g, b] = match.map(x => parseInt(x, 16))
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+export default function CallNamePage() {
+  const { characterInfos, callNameInfos } = useDetailedCharacterInfo()
+  const { characterKeys } = useContext(CharacterContext)
+  console.log(characterInfos, characterKeys)
+
+  const getColumnRGB = (characterKey: CharacterKey): string =>
+    characterInfos[characterKey].lightColor
+
+  function getColumn(characterKey: CharacterKey): ReactElement[] {
+    return characterKeys.map(_characterKey => {
+      const characterInfo = characterInfos[_characterKey]
+      const callNameInfo = callNameInfos[characterKey]
+
+      const callName = callNameInfo[_characterKey]
+      const callNameSplit = callName ? callName.split("/") : []
+
+      return (
+        <td key={_characterKey} style={{ verticalAlign: "middle" }}>
+          {callName &&
+            callNameSplit.map((part, index) => (
+              <span key={index}>
+                {part}
+                {index !== callNameSplit.length - 1 ? <br /> : ""}
+              </span>
+            ))}
+        </td>
+      )
+    })
+  }
+
+  return (
+    <Page>
+      <div
+        style={{
+          padding: "20px",
+          width: "200%",
+          overflow: "auto",
+        }}
+      >
+        <table
+          border={1}
+          style={{
+            tableLayout: "fixed",
+            width: "100%",
+            textAlign: "center",
+          }}
+        >
+          <thead>
+            <tr>
+              <th></th>
+              {characterKeys.map(characterKey => {
+                const characterInfo = characterInfos[characterKey]
+                return (
+                  <th
+                    key={characterKey}
+                    style={{
+                      verticalAlign: "middle",
+                    }}
+                  >
+                    {characterInfo.name}
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {characterKeys.map(characterKey => {
+              const characterInfo = characterInfos[characterKey]
+              return (
+                <tr
+                  key={characterKey}
+                  style={{
+                    backgroundColor: hex2rgba(getColumnRGB(characterKey), 0.5),
+                  }}
+                >
+                  <td
+                    height={40}
+                    style={{
+                      verticalAlign: "middle",
+                    }}
+                  >
+                    {characterInfo.name}
+                  </td>
+                  {getColumn(characterKey)}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </Page>
+  )
+}

--- a/src/pages/dormitory/call-name/index.tsx
+++ b/src/pages/dormitory/call-name/index.tsx
@@ -1,9 +1,11 @@
-import { Page } from "../../components/page"
+import { Page } from "../../../components/page"
 import React, { ReactElement, useContext } from "react"
-import { useDetailedCharacterInfo } from "../../hooks/useDetailedCharacterInfo"
-import { CharacterContext } from "../../contexts/context"
-import { CharacterKey } from "../../types/dormitoryCharacter"
+import { useDetailedCharacterInfo } from "../../../hooks/useDetailedCharacterInfo"
+import { CharacterContext } from "../../../contexts/context"
+import { CharacterKey } from "../../../types/dormitoryCharacter"
 import { GatsbyImage } from "gatsby-plugin-image"
+import { Link } from "gatsby"
+import Seo from "../../../components/seo"
 
 function hex2rgba(hex: string, alpha = 1): [number, number, number, number] {
   const match = hex.match(/\w\w/g)
@@ -36,7 +38,6 @@ export default function CallNamePage() {
         alt={characterInfo.name}
         imgStyle={{ width: "50px" }}
         style={{
-          borderColor: characterInfo.color,
           width: "50px",
           aspectRatio: "1/1",
         }}
@@ -75,6 +76,13 @@ export default function CallNamePage() {
 
   return (
     <Page>
+      <Seo
+        title={`キャラクターの呼称表 | ボイボ寮 | VOICEVOX`}
+        description={
+          "ボイボ寮のキャラクターの呼び方一覧表です。必ずしも遵守する必要はなく、自由に改変して頂いても問題ありません。"
+        }
+      />
+
       <section style={{ padding: "20px" }}>
         <h1 className="title">キャラクターの呼称表</h1>
         <p>
@@ -98,8 +106,10 @@ export default function CallNamePage() {
                 const characterInfo = characterInfos[characterKey]
                 return (
                   <th key={characterKey}>
-                    {getCharacterImage(characterKey)}
-                    <p>{characterInfo.name}</p>
+                    <Link to={`/dormitory/${characterInfo.id}/`}>
+                      {getCharacterImage(characterKey)}
+                      <p>{characterInfo.name}</p>
+                    </Link>
                   </th>
                 )
               })}
@@ -113,7 +123,7 @@ export default function CallNamePage() {
               // 色を半透明するとセルが重なったとき, スクロール時にセルが
               // 透けて見えてしまうので, 白地での RGB に変換する
               const [red, green, blue] = rgba2rgbOnWhite(
-                ...hex2rgba(characterInfo.lightColor, 0.5)
+                ...hex2rgba(characterInfo.lightColor, 0.4)
               )
               const backgroundColor = `rgb(${red}, ${green}, ${blue})`
 
@@ -124,9 +134,15 @@ export default function CallNamePage() {
                       <p>{callName}</p>
                     ))}
                   </td>
-                  <th style={{ backgroundColor }}>
-                    {getCharacterImage(characterKey)}
-                    <p>{characterInfo.name}</p>
+                  <th
+                    style={{
+                      backgroundColor,
+                    }}
+                  >
+                    <Link to={`/dormitory/${characterInfo.id}/`}>
+                      {getCharacterImage(characterKey)}
+                      <p>{characterInfo.name}</p>
+                    </Link>
                   </th>
                   {getColumn(characterKey)}
                 </tr>


### PR DESCRIPTION
## 内容

###### お久しぶりです
ボイボ寮キャラクターの呼称表 (呼び方一覧表) を追加します.  


## 関連 Issue

close: #134 

## スクリーンショット・動画など

_作成中_

## その他
> 左と上に呼ぶ人呼ばれる人が固定表示されてて、地図みたいにスクロールできるとたのしそう。  (https://github.com/VOICEVOX/voicevox_blog/issues/134#:~:text=UI%E3%81%8C%E8%AC%8E-,%E5%AE%9F%E7%8F%BE%E6%96%B9%E6%B3%95,-%E5%B7%A6%E3%81%A8%E4%B8%8A)

より, 最初の列と行を固定します.