### PR TITLE
Add: ボイボ寮キャラクターの呼称のコピー機能 + リファクタリング

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -881,6 +881,7 @@ $call-names-cell-width-column: 190px;
       position: sticky;
       top: 0;
       left: 0;
+      z-index: 1;
     }
 
     th,
@@ -921,10 +922,32 @@ $call-names-cell-width-column: 190px;
           flex-direction: column;
           justify-content: center;
 
+          position: relative;
+
+          // コピーボタン
+          .icon {
+            @extend .m-1;
+
+            visibility: hidden;
+            position: absolute;
+            height: 1rem;
+            width: 1rem;
+            top: 0;
+            right: 0;
+
+            &.selected {
+              visibility: visible;
+            }
+          }
+
           &:hover {
             // NOTE: ちらつくので border ではなく outline
             outline: 2px solid;
             border-radius: $radius;
+
+            .icon {
+              visibility: visible;
+            }
           }
         }
       }
@@ -939,7 +962,7 @@ $call-names-cell-width-column: 190px;
         // 左上のセル
         &.origin {
           width: $call-names-cell-width-column;
-          z-index: 1;
+          z-index: 2;
           border-right: $call-names-border;
         }
 

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -847,18 +847,6 @@ $call-names-cell-height: 80px;
 $call-names-cell-width: 150px;
 $call-names-cell-width-column: 190px;
 
-@keyframes call-names-column-highlight {
-  0% {
-    outline-width: 0px;
-  }
-  99% {
-    outline-width: 4px;
-  }
-  100% {
-    outline-width: 0px;
-  }
-}
-
 .call-names-wrapper {
   // sticky にするために明示的に高さを指定
   //  → ほかに overflow の指定などでも sticky にできるが、親レイアウトの
@@ -962,14 +950,6 @@ $call-names-cell-width-column: 190px;
             }
           }
         }
-      }
-    }
-
-    tr {
-      &.highlight {
-        animation: call-names-column-highlight 1.25s 3 forwards;
-        outline-style: solid;
-        border-radius: $radius;
       }
     }
 

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -847,6 +847,18 @@ $call-names-cell-height: 80px;
 $call-names-cell-width: 150px;
 $call-names-cell-width-column: 190px;
 
+@keyframes call-names-column-highlight {
+  0% {
+    outline-width: 0px;
+  }
+  99% {
+    outline-width: 4px;
+  }
+  100% {
+    outline-width: 0px;
+  }
+}
+
 .call-names-wrapper {
   // sticky にするために明示的に高さを指定
   //  → ほかに overflow の指定などでも sticky にできるが、親レイアウトの
@@ -950,6 +962,14 @@ $call-names-cell-width-column: 190px;
             }
           }
         }
+      }
+    }
+
+    tr {
+      &.highlight {
+        animation: call-names-column-highlight 1.25s 3 forwards;
+        outline-style: solid;
+        border-radius: $radius;
       }
     }
 

--- a/src/pages/dormitory.tsx
+++ b/src/pages/dormitory.tsx
@@ -258,7 +258,7 @@ const Dormitory: React.FC<DormitoryProps> = ({ setShowingHeader }) => {
             <div className="has-text-centered pt-2 pb-0">
               <h2 className="title is-4">関連コンテンツ</h2>
               <Link
-                to="/dormitory/call-names/"
+                to="/dormitory/call_names/"
                 className="button is-normal is-rounded"
                 type="button"
                 role={"button"}

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -52,7 +52,7 @@ export default function CallNamesPage() {
 
     const timer = setTimeout(() => {
       setSelectedCallName(undefined)
-    }, 3000)
+    }, 1500)
 
     // クリーンアップ; 他のセルのクリックでタイマークリア
     return () => {

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -36,7 +36,7 @@ function rgba2rgbOnWhite(
   return [_red, _green, _blue]
 }
 
-function CallNamesColumn({
+function Column({
   characterKey,
 }: {
   characterKey: CharacterKey
@@ -48,28 +48,23 @@ function CallNamesColumn({
     characterKey: CharacterKey
     callName: string
   }>()
-
-  useEffect(() => {
-    if (selectedCallName == null) return
-
-    navigator.clipboard.writeText(selectedCallName.callName)
-
-    const timer = setTimeout(() => {
-      setSelectedCallName(undefined)
-    }, 1500)
-
-    // クリーンアップ; 他のセルのクリックでタイマークリア
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [selectedCallName])
+  const [showCopiedIcon, setShowCopiedIcon] = useState(false)
 
   const callNameInfo = callNameInfos[characterKey]
   const characterInfo = characterInfos[characterKey]
-
   const outlineStyle: CSSProperties = {
     outlineColor: characterInfo.color,
   }
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowCopiedIcon(false)
+    }, 1500)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [showCopiedIcon])
 
   function copyToClipboard(event: MouseEvent<HTMLInputElement>): void {
     const callName = event.currentTarget.innerText
@@ -78,6 +73,8 @@ function CallNamesColumn({
       characterKey,
       callName,
     })
+    navigator.clipboard.writeText(callName)
+    setShowCopiedIcon(true)
   }
 
   function Cell({
@@ -91,7 +88,8 @@ function CallNamesColumn({
   }): ReactElement {
     const isSelected =
       selectedCallName?.characterKey === characterKey &&
-      selectedCallName?.callName === callName
+      selectedCallName?.callName === callName &&
+      showCopiedIcon
 
     return (
       <p
@@ -134,7 +132,7 @@ function CallNamesColumn({
                 if (callName == undefined) {
                   return (
                     <p
-                      key={`${_characterKey}-?`}
+                      key={`${_characterKey}-unknown`}
                       className="unknown"
                       style={outlineStyle}
                     >
@@ -277,7 +275,7 @@ export default function CallNamesPage() {
                         </p>
                       </Link>
                     </th>
-                    <CallNamesColumn characterKey={characterKey} />
+                    <Column characterKey={characterKey} />
                   </tr>
                 )
               })}

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -8,12 +8,12 @@ import React, {
   useState,
   useEffect,
 } from "react"
-import { Page } from "../../../components/page"
-import Seo from "../../../components/seo"
-import { CharacterContext } from "../../../contexts/context"
-import { useDetailedCharacterInfo } from "../../../hooks/useDetailedCharacterInfo"
-import { CharacterKey } from "../../../types/dormitoryCharacter"
-import { DormitoryExplainComponent } from "../../dormitory"
+import { Page } from "../../components/page"
+import Seo from "../../components/seo"
+import { CharacterContext } from "../../contexts/context"
+import { useDetailedCharacterInfo } from "../../hooks/useDetailedCharacterInfo"
+import { CharacterKey } from "../../types/dormitoryCharacter"
+import { DormitoryExplainComponent } from "../dormitory"
 import { faCopy, faCheck } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -44,10 +44,7 @@ function Column({
   const { characterInfos, callNameInfos } = useDetailedCharacterInfo()
   const { characterKeys } = useContext(CharacterContext)
 
-  const [selectedCallName, setSelectedCallName] = useState<{
-    characterKey: CharacterKey
-    callName: string
-  }>()
+  const [selectedCallName, setSelectedCallName] = useState<string>()
   const [showCopiedIcon, setShowCopiedIcon] = useState(false)
 
   const callNameInfo = callNameInfos[characterKey]
@@ -57,6 +54,8 @@ function Column({
   }
 
   useEffect(() => {
+    if (selectedCallName == undefined) return
+
     const timer = setTimeout(() => {
       setShowCopiedIcon(false)
     }, 1500)
@@ -64,15 +63,12 @@ function Column({
     return () => {
       clearTimeout(timer)
     }
-  }, [showCopiedIcon])
+  }, [showCopiedIcon, selectedCallName])
 
   function copyToClipboard(event: MouseEvent<HTMLInputElement>): void {
     const callName = event.currentTarget.innerText
 
-    setSelectedCallName({
-      characterKey,
-      callName,
-    })
+    setSelectedCallName(callName)
     navigator.clipboard.writeText(callName)
     setShowCopiedIcon(true)
   }
@@ -86,10 +82,7 @@ function Column({
     callName: string
     externalClassName?: string
   }): ReactElement {
-    const isSelected =
-      selectedCallName?.characterKey === characterKey &&
-      selectedCallName?.callName === callName &&
-      showCopiedIcon
+    const isSelected = selectedCallName === callName && showCopiedIcon
 
     return (
       <p

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -66,9 +66,12 @@ export default function CallNamesPage() {
       throw new Error("Character element not found")
     }
 
-    // 中心にキャラクターが来るようにスクロール
+    // 該当列をハイライトする
+    characterElem.classList.add("highlight")
+
+    // 画面の中心にキャラクターが来るようにスクロール
     characterElem.scrollIntoView({ block: "center", behavior: "instant" })
-    // 微妙に親スクロールが動くので, もとに戻す
+    // 微妙に親スクロールの y 軸が動くので, もとに戻す
     window.scrollTo(0, 0)
   }
 
@@ -252,19 +255,15 @@ export default function CallNamesPage() {
                   ...hex2rgba(characterInfo.lightColor, 0.4)
                 )
                 const backgroundColor = `rgb(${red}, ${green}, ${blue})`
+                const outlineColor = characterInfo.color
 
                 return (
-                  // FIXME: #id でキャラクターに直接アクセスするとスクロールがずれるのを直す
                   <tr
                     key={characterKey}
                     id={characterInfo.id}
-                    style={{ backgroundColor }}
+                    style={{ backgroundColor, outlineColor }}
                   >
-                    <th
-                      style={{
-                        backgroundColor,
-                      }}
-                    >
+                    <th>
                       <Link to={`/dormitory/${characterInfo.id}/`}>
                         {getCharacterImage(characterKey)}
                         <p

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -74,11 +74,9 @@ function Column({
   }
 
   function Cell({
-    characterKey,
     callName,
     externalClassName,
   }: {
-    characterKey: string
     callName: string
     externalClassName?: string
   }): ReactElement {
@@ -115,7 +113,6 @@ function Column({
                   return callNameInfo.me.map(part => (
                     <Cell
                       key={`me-${part}`}
-                      characterKey={characterKey}
                       callName={part}
                       externalClassName="me"
                     />
@@ -137,11 +134,7 @@ function Column({
                 return callName
                   .split("/")
                   .map(part => (
-                    <Cell
-                      key={`${_characterKey}-${part}`}
-                      characterKey={characterKey}
-                      callName={part}
-                    />
+                    <Cell key={`${_characterKey}-${part}`} callName={part} />
                   ))
               })()}
             </div>
@@ -151,11 +144,7 @@ function Column({
       <td className="you">
         <div>
           {callNameInfo.you.map(part => (
-            <Cell
-              key={`you-${part}`}
-              characterKey={characterKey}
-              callName={part}
-            />
+            <Cell key={`you-${part}`} callName={part} />
           ))}
         </div>
       </td>

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -45,37 +45,6 @@ export default function CallNamesPage() {
     callName: string
   }>()
 
-  const jump2characterColumn = async (): Promise<void> => {
-    const urlAnchor = window.location.hash
-    if (!urlAnchor.length) return
-
-    window.scrollTo(0, 0)
-
-    const characterKeyFromAnchor = urlAnchor.slice(1)
-    const characterIdList = characterKeys.map(
-      characterKey => characterInfos[characterKey].id
-    )
-
-    if (!characterIdList.includes(characterKeyFromAnchor)) {
-      console.warn(`Unknown anchor: ${urlAnchor}`)
-      return
-    }
-
-    const characterElem = document.getElementById(characterKeyFromAnchor)
-    if (characterElem == null) {
-      throw new Error("Character element not found")
-    }
-
-    // 中心にキャラクターが来るようにスクロール
-    characterElem.scrollIntoView({ block: "center", behavior: "instant" })
-    // 微妙に親スクロールが動くので, もとに戻す
-    window.scrollTo(0, 0)
-  }
-
-  useEffect(() => {
-    void jump2characterColumn()
-  }, [])
-
   useEffect(() => {
     if (selectedCallName == null) return
 
@@ -254,12 +223,7 @@ export default function CallNamesPage() {
                 const backgroundColor = `rgb(${red}, ${green}, ${blue})`
 
                 return (
-                  // FIXME: #id でキャラクターに直接アクセスするとスクロールがずれるのを直す
-                  <tr
-                    key={characterKey}
-                    id={characterInfo.id}
-                    style={{ backgroundColor }}
-                  >
+                  <tr key={characterKey} style={{ backgroundColor }}>
                     <th
                       style={{
                         backgroundColor,

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -45,6 +45,37 @@ export default function CallNamesPage() {
     callName: string
   }>()
 
+  const jump2characterColumn = async (): Promise<void> => {
+    const urlAnchor = window.location.hash
+    if (!urlAnchor.length) return
+
+    window.scrollTo(0, 0)
+
+    const characterKeyFromAnchor = urlAnchor.slice(1)
+    const characterIdList = characterKeys.map(
+      characterKey => characterInfos[characterKey].id
+    )
+
+    if (!characterIdList.includes(characterKeyFromAnchor)) {
+      console.warn(`Unknown anchor: ${urlAnchor}`)
+      return
+    }
+
+    const characterElem = document.getElementById(characterKeyFromAnchor)
+    if (characterElem == null) {
+      throw new Error("Character element not found")
+    }
+
+    // 中心にキャラクターが来るようにスクロール
+    characterElem.scrollIntoView({ block: "center", behavior: "instant" })
+    // 微妙に親スクロールが動くので, もとに戻す
+    window.scrollTo(0, 0)
+  }
+
+  useEffect(() => {
+    void jump2characterColumn()
+  }, [])
+
   useEffect(() => {
     if (selectedCallName == null) return
 
@@ -81,7 +112,6 @@ export default function CallNamesPage() {
 
     function copyToClipboard(event: MouseEvent<HTMLInputElement>): void {
       const callName = event.currentTarget.innerText
-      console.log(callName)
 
       setSelectedCallName({
         characterKey,
@@ -104,6 +134,7 @@ export default function CallNamesPage() {
           className={externalClassName}
           onClick={copyToClipboard}
           style={outlineStyle}
+          title={`クリックして呼称をコピー: 「${callName}」`}
         >
           <span className={`icon ${isSelected ? "selected" : ""}`}>
             <FontAwesomeIcon

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -36,6 +36,7 @@ function rgba2rgbOnWhite(
   return [_red, _green, _blue]
 }
 
+// FIXME: Row
 function Column({
   characterKey,
 }: {

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -103,7 +103,7 @@ export default function CallNamesPage() {
           className={externalClassName}
           onClick={copyToClipboard}
           style={outlineStyle}
-          title={`クリックして呼称をコピー: 「${callName}」`}
+          title={`クリックして呼称をコピー：「${callName}」`}
         >
           <span className={`icon ${isSelected ? "selected" : ""}`}>
             <FontAwesomeIcon
@@ -134,7 +134,7 @@ export default function CallNamesPage() {
                   if (callName == undefined) {
                     return (
                       <p className="unknown" style={outlineStyle}>
-                        ?
+                        ？
                       </p>
                     )
                   }

--- a/src/pages/dormitory/call_names.tsx
+++ b/src/pages/dormitory/call_names.tsx
@@ -66,12 +66,9 @@ export default function CallNamesPage() {
       throw new Error("Character element not found")
     }
 
-    // 該当列をハイライトする
-    characterElem.classList.add("highlight")
-
-    // 画面の中心にキャラクターが来るようにスクロール
+    // 中心にキャラクターが来るようにスクロール
     characterElem.scrollIntoView({ block: "center", behavior: "instant" })
-    // 微妙に親スクロールの y 軸が動くので, もとに戻す
+    // 微妙に親スクロールが動くので, もとに戻す
     window.scrollTo(0, 0)
   }
 
@@ -255,15 +252,19 @@ export default function CallNamesPage() {
                   ...hex2rgba(characterInfo.lightColor, 0.4)
                 )
                 const backgroundColor = `rgb(${red}, ${green}, ${blue})`
-                const outlineColor = characterInfo.color
 
                 return (
+                  // FIXME: #id でキャラクターに直接アクセスするとスクロールがずれるのを直す
                   <tr
                     key={characterKey}
                     id={characterInfo.id}
-                    style={{ backgroundColor, outlineColor }}
+                    style={{ backgroundColor }}
                   >
-                    <th>
+                    <th
+                      style={{
+                        backgroundColor,
+                      }}
+                    >
                       <Link to={`/dormitory/${characterInfo.id}/`}>
                         {getCharacterImage(characterKey)}
                         <p


### PR DESCRIPTION
## 内容

ボイボ寮キャラクターの呼称表 (呼び方一覧表) のコピー機能を実装します.  
また, #163 に関連して以下のような修正を行います:  

~~- URL アンカー (`#{characterId}`) で飛んだときに画面の中心にスクロールするように~~
~~- ﾁｮｯﾄハイライトアニメーション付けました (discord/slack みたいな)~~
- ボイボ寮にある呼称表へ飛ばすリンクが `call-names` になったまま (#167 のミス？) なので `call_names` に
- セルにホバーしたら, “クリックしてコピー: 「ずんだもん」” のように出てくるようにしてみました

## 関連 Issue

refs:  
- #163 
- #167 

## スクリーンショット・動画など

_準備中_

## その他

不要な機能があれば遠慮なくお教えください！！！