### PR TITLE
ボイボ寮のキャラクター一覧の見た目を改善

### DIFF
--- a/src/components/dormitoryCharacterCard.tsx
+++ b/src/components/dormitoryCharacterCard.tsx
@@ -31,7 +31,10 @@ export default ({
               alt={characterInfo.name}
               objectFit="contain"
             />
-            <div className="card-content has-text-centered">
+            <div
+              className="card-content has-text-centered"
+              style={{ borderColor: color }}
+            >
               <h3 className="title is-5">{characterInfo.name}</h3>
             </div>
           </Link>

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -485,7 +485,7 @@ $dropdown-item-active-background-color: $primary;
 
       &.character-container {
         .columns:not(:last-child) {
-          margin-bottom: -0.75rem;
+          margin-bottom: -0.75rem; // columnsは下方向のmargin調整がないので、hrの辻褄を合わせに必要
         }
 
         .generation-label {
@@ -501,7 +501,7 @@ $dropdown-item-active-background-color: $primary;
 
         .jump-anchor-header-padding {
           // カード間の余白を均等にする
-          padding-top: calc(3.25rem + 1rem + 0.75rem);
+          padding-top: calc(3.25rem + 1rem + 0.75rem); // 元が3.25rem + 1rem、column分が0.75rem
         }
 
         .card {
@@ -512,7 +512,7 @@ $dropdown-item-active-background-color: $primary;
         }
 
         .character-card {
-          @extend .pt-5;
+          @extend .pt-3;
           cursor: pointer;
 
           .card-image {
@@ -522,7 +522,7 @@ $dropdown-item-active-background-color: $primary;
           .card-content {
             @extend .px-0;
             @extend .has-text-centered;
-            border-top: solid 3px;
+            border-top: solid 2.5px;
           }
         }
 

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -484,6 +484,10 @@ $dropdown-item-active-background-color: $primary;
       background-color: white;
 
       &.character-container {
+        .columns:not(:last-child) {
+          margin-bottom: -0.75rem;
+        }
+
         .generation-label {
           @extend .has-text-centered;
           display: flex;
@@ -495,6 +499,11 @@ $dropdown-item-active-background-color: $primary;
           }
         }
 
+        .jump-anchor-header-padding {
+          // カード間の余白を均等にする
+          padding-top: calc(3.25rem + 1rem + 0.75rem);
+        }
+
         .card {
           box-shadow: none;
           border-style: solid;
@@ -503,6 +512,7 @@ $dropdown-item-active-background-color: $primary;
         }
 
         .character-card {
+          @extend .pt-5;
           cursor: pointer;
 
           .card-image {
@@ -512,6 +522,7 @@ $dropdown-item-active-background-color: $primary;
           .card-content {
             @extend .px-0;
             @extend .has-text-centered;
+            border-top: solid 3px;
           }
         }
 
@@ -523,7 +534,6 @@ $dropdown-item-active-background-color: $primary;
           .card-content {
             @extend .px-0;
             @extend .has-text-centered;
-            border-top: solid 3px;
           }
         }
 

--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -523,6 +523,7 @@ $dropdown-item-active-background-color: $primary;
           .card-content {
             @extend .px-0;
             @extend .has-text-centered;
+            border-top: solid 3px;
           }
         }
 

--- a/src/pages/dormitory.tsx
+++ b/src/pages/dormitory.tsx
@@ -59,8 +59,6 @@ const Dormitory: React.FC<DormitoryProps> = ({ setShowingHeader }) => {
 
         <main className="section pt-0 pb-5">
           <div className="container character-container is-max-desktop pt-1 pb-6">
-            <hr />
-
             <div className="columns is-multiline">
               <div
                 id="7th"

--- a/src/pages/dormitory.tsx
+++ b/src/pages/dormitory.tsx
@@ -59,6 +59,8 @@ const Dormitory: React.FC<DormitoryProps> = ({ setShowingHeader }) => {
 
         <main className="section pt-0 pb-5">
           <div className="container character-container is-max-desktop pt-1 pb-6">
+            <hr />
+
             <div className="columns is-multiline">
               <div
                 id="7th"


### PR DESCRIPTION
## 内容
以下を実施しました。
- キャラクター画像が途切れてる感じをなくす
  - 画像の上にpaddingを追加
  - 画像と名前の間にも罫線を追加
- キャラクターカードの縦の見かけ上のpaddingを横に合わせる
- 7期生の上にも水平線(hr)を追加
- 水平線の位置を微調整
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## スクリーンショット・動画など
PC変更前
![image](https://github.com/VOICEVOX/voicevox_blog/assets/7900586/b58e9835-5d91-470b-9f4f-9e292764a9b8)
PC変更後
![image](https://github.com/VOICEVOX/voicevox_blog/assets/7900586/1462d2dc-2b80-4ef0-b0c6-ffdba8894536)

モバイル変更前
![image](https://github.com/VOICEVOX/voicevox_blog/assets/7900586/273b98ff-f446-4a0a-8607-f3b3fba2df41)

モバイル変更後
![image](https://github.com/VOICEVOX/voicevox_blog/assets/7900586/1e18bdad-9aba-4bc9-aa62-7c4b4d3f260d)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
`display: grid`で書きなおした方が良さそうにも見えますが、とりあえず現状に合わせました。