### PR TITLE
Mainページを適切にメモ化する

### DIFF
--- a/src/components/audioSample.tsx
+++ b/src/components/audioSample.tsx
@@ -2,64 +2,66 @@ import React, { useMemo } from "react"
 import PlayButton from "./playButton"
 import StyleDropdown, { useStyleDropdownController } from "./styleDropdown"
 
-const AudioSample = ({
-  audioSamples,
-  characterName,
-  className,
-}: {
-  audioSamples: { style: string; urls: readonly string[] }[]
-  characterName: string
-} & React.HTMLAttributes<HTMLDivElement>) => {
-  const styles = useMemo(
-    () => audioSamples.map(value => value.style),
-    [audioSamples]
-  )
-  const { selectedStyle, setSelectedStyle } = useStyleDropdownController({
-    styles,
-  })
-  const selectedAudioUrls = useMemo(
-    () => audioSamples.find(({ style }) => style == selectedStyle)!.urls,
-    [audioSamples, selectedStyle]
-  )
+const AudioSample = React.memo(
+  ({
+    audioSamples,
+    characterName,
+    className,
+  }: {
+    audioSamples: { style: string; urls: readonly string[] }[]
+    characterName: string
+  } & React.HTMLAttributes<HTMLDivElement>) => {
+    const styles = useMemo(
+      () => audioSamples.map(value => value.style),
+      [audioSamples]
+    )
+    const { selectedStyle, setSelectedStyle } = useStyleDropdownController({
+      styles,
+    })
+    const selectedAudioUrls = useMemo(
+      () => audioSamples.find(({ style }) => style == selectedStyle)!.urls,
+      [audioSamples, selectedStyle]
+    )
 
-  return (
-    <div className={"audio-sample " + className}>
-      <hr className="my-3" />
-      <div className="audio-sample-pair">
-        <div className="audio-sample-label">
-          <span>音声サンプル</span>
-        </div>
-        <div className="audio-sample-content">
-          {selectedAudioUrls.map((url, index) => (
-            <PlayButton
-              key={index}
-              url={url}
-              name={`${characterName}の${selectedStyle}スタイルのサンプルボイス${
-                index + 1
-              }`}
-              className="is-small"
-            />
-          ))}
-        </div>
-      </div>
-      {styles.length > 1 && (
+    return (
+      <div className={"audio-sample " + className}>
+        <hr className="my-3" />
         <div className="audio-sample-pair">
           <div className="audio-sample-label">
-            <span>スタイル</span>
+            <span>音声サンプル</span>
           </div>
           <div className="audio-sample-content">
-            <StyleDropdown
-              styles={styles}
-              selectedStyle={selectedStyle}
-              setSelectedStyle={setSelectedStyle}
-              characterName={characterName}
-            />
+            {selectedAudioUrls.map((url, index) => (
+              <PlayButton
+                key={index}
+                url={url}
+                name={`${characterName}の${selectedStyle}スタイルのサンプルボイス${
+                  index + 1
+                }`}
+                className="is-small"
+              />
+            ))}
           </div>
         </div>
-      )}
-      <hr className="my-3" />
-    </div>
-  )
-}
+        {styles.length > 1 && (
+          <div className="audio-sample-pair">
+            <div className="audio-sample-label">
+              <span>スタイル</span>
+            </div>
+            <div className="audio-sample-content">
+              <StyleDropdown
+                styles={styles}
+                selectedStyle={selectedStyle}
+                setSelectedStyle={setSelectedStyle}
+                characterName={characterName}
+              />
+            </div>
+          </div>
+        )}
+        <hr className="my-3" />
+      </div>
+    )
+  }
+)
 
 export default AudioSample

--- a/src/hooks/useDetailedCharacterInfo.ts
+++ b/src/hooks/useDetailedCharacterInfo.ts
@@ -1,9 +1,6 @@
 import { graphql, useStaticQuery } from "gatsby"
-import {
-  CharacterInfo,
-  CharacterKey,
-  Generation,
-} from "../types/dormitoryCharacter"
+import { useMemo } from "react"
+import { CharacterInfo, CharacterKey } from "../types/dormitoryCharacter"
 import { useCharacterInfo } from "./useCharacterInfo"
 
 export const useDetailedCharacterInfo = () => {
@@ -251,7 +248,9 @@ export const useDetailedCharacterInfo = () => {
     return item
   }
 
-  const characterInfos: {
+  // キャラクターの詳細情報
+  // ネストを浅くするために一旦変数に格納
+  const _characterInfos: {
     [key in CharacterKey]: CharacterInfo
   } = {
     四国めたん: {
@@ -917,28 +916,16 @@ export const useDetailedCharacterInfo = () => {
     },
   } as const
 
-  const generationInfos: {
-    [key in Generation]: { characterKeys: readonly CharacterKey[] }
-  } = {
-    一期生: { characterKeys: ["四国めたん", "ずんだもん"] },
-    二期生: {
-      characterKeys: ["春日部つむぎ", "雨晴はう", "波音リツ"],
-    },
-    三期生: {
-      characterKeys: [
-        "玄野武宏",
-        "白上虎太郎",
-        "青山龍星",
-        "冥鳴ひまり",
-        "九州そら",
-      ],
-    },
-  } as const
+  const characterInfos = useMemo(() => _characterInfos, [])
+  const callNameInfos = useMemo(() => _callNameInfos, [])
 
-  return { characterInfos, callNameInfos, generationInfos } as const
+  return {
+    characterInfos,
+    callNameInfos,
+  } as const
 }
 
-const callNameInfos: {
+const _callNameInfos: {
   [key in CharacterKey]: {
     [key in CharacterKey]?: string | undefined
   } & { me: readonly string[]; you: readonly string[] }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,36 +15,22 @@ import landingMovieThumb from "../images/landing-movie-thumb.png"
 import shareThumb from "../images/landing-share-thumb.jpg"
 import Logo from "../images/logo.svg"
 import landingMovie from "../movies/landing.mp4"
-import { CharacterKey } from "../types/dormitoryCharacter"
+import { CharacterInfo, CharacterKey } from "../types/dormitoryCharacter"
 import { getProductPageUrl } from "../urls"
 
-const Main: React.FC<{ setShowingHeader: (show: boolean) => void }> = ({
-  setShowingHeader,
-}) => {
-  const { characterInfos } = useDetailedCharacterInfo()
-
-  const { characterKeys } = useContext(CharacterContext)
-
-  // ファーストビュー用のビューを超えたらヘッダーを表示する
-  const firstViewRef = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (!firstViewRef.current) return
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        setShowingHeader(!entry.isIntersecting)
-      })
-    })
-    observer.observe(firstViewRef.current)
-  }, [firstViewRef])
-
-  const [
-    showingLibraryReadmeModalCharacterKey,
+// キャラクター表示
+const CharacterCard = React.memo(
+  ({
+    characterInfo,
+    characterKey,
     setShowingLibraryReadmeModalCharacterKey,
-  ] = useState<CharacterKey | undefined>(undefined)
-
-  // キャラクター表示
-  const CharacterCard = ({ characterKey }: { characterKey: CharacterKey }) => {
-    const characterInfo = characterInfos[characterKey]
+  }: {
+    characterInfo: CharacterInfo
+    characterKey: CharacterKey
+    setShowingLibraryReadmeModalCharacterKey: (
+      characterKey: CharacterKey
+    ) => void
+  }) => {
     if (!characterInfo)
       throw new Error(`characterInfo is undefined. (${characterKey})`)
     const LinkToProductPage = ({
@@ -109,230 +95,265 @@ const Main: React.FC<{ setShowingHeader: (show: boolean) => void }> = ({
       </div>
     )
   }
+)
 
-  return (
-    <>
-      <Seo
-        title="VOICEVOX | 無料のテキスト読み上げソフトウェア"
-        description="無料で使える中品質なテキスト読み上げソフトウェア。商用・非商用問わず無料で、誰でも簡単にお使いいただけます。イントネーションを詳細に調整することも可能です。"
-        image={shareThumb}
-      />
+const Main = React.memo(
+  ({ setShowingHeader }: { setShowingHeader: (show: boolean) => void }) => {
+    const { characterInfos } = useDetailedCharacterInfo()
 
-      <div className="landing">
-        <div ref={firstViewRef} className="first-view">
-          <header className="hero is-primary is-small">
-            <div className="hero-body">
-              <div className="container has-text-centered">
-                <div className="title top-title">
-                  <Logo alt="VOICEVOX" />
+    const { characterKeys } = useContext(CharacterContext)
+
+    // ファーストビュー用のビューを超えたらヘッダーを表示する
+    const firstViewRef = useRef<HTMLDivElement>(null)
+    useEffect(() => {
+      if (!firstViewRef.current) return
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          setShowingHeader(!entry.isIntersecting)
+        })
+      })
+      observer.observe(firstViewRef.current)
+    }, [firstViewRef])
+
+    const [
+      showingLibraryReadmeModalCharacterKey,
+      setShowingLibraryReadmeModalCharacterKey,
+    ] = useState<CharacterKey | undefined>(undefined)
+
+    return (
+      <>
+        <Seo
+          title="VOICEVOX | 無料のテキスト読み上げソフトウェア"
+          description="無料で使える中品質なテキスト読み上げソフトウェア。商用・非商用問わず無料で、誰でも簡単にお使いいただけます。イントネーションを詳細に調整することも可能です。"
+          image={shareThumb}
+        />
+
+        <div className="landing">
+          <div ref={firstViewRef} className="first-view">
+            <header className="hero is-primary is-small">
+              <div className="hero-body">
+                <div className="container has-text-centered">
+                  <div className="title top-title">
+                    <Logo alt="VOICEVOX" />
+                  </div>
+                  <h2 className="subtitle has-text-weight-semibold">
+                    無料で使える中品質なテキスト読み上げソフトウェア
+                  </h2>
                 </div>
-                <h2 className="subtitle has-text-weight-semibold">
-                  無料で使える中品質なテキスト読み上げソフトウェア
+              </div>
+            </header>
+            <section className="section not-header is-flex is-justify-content-center">
+              <div className="container is-max-desktop columns is-desktop is-vcentered">
+                <div className="column has-text-centered">
+                  <video controls poster={landingMovieThumb}>
+                    <source src={landingMovie} type="video/mp4" />
+                  </video>
+                </div>
+                <SoftwareFeature className="column is-narrow" />
+              </div>
+            </section>
+          </div>
+
+          <main>
+            <section className="section">
+              <div className="container is-max-desktop is-flex is-flex-direction-column">
+                <h2
+                  id="characters"
+                  className="jump-anchor-header-padding title"
+                >
+                  <Link to={`#characters`} className="has-text-black">
+                    キャラクター一覧
+                  </Link>
                 </h2>
+                <div className="columns is-multiline is-centered">
+                  {characterKeys.map(characterKey => (
+                    <CharacterCard
+                      key={characterKey}
+                      characterInfo={characterInfos[characterKey]}
+                      characterKey={characterKey}
+                      setShowingLibraryReadmeModalCharacterKey={
+                        setShowingLibraryReadmeModalCharacterKey
+                      }
+                    />
+                  ))}
+                </div>
               </div>
-            </div>
-          </header>
-          <section className="section not-header is-flex is-justify-content-center">
-            <div className="container is-max-desktop columns is-desktop is-vcentered">
-              <div className="column has-text-centered">
-                <video controls poster={landingMovieThumb}>
-                  <source src={landingMovie} type="video/mp4" />
-                </video>
-              </div>
-              <SoftwareFeature className="column is-narrow" />
-            </div>
-          </section>
-        </div>
+            </section>
 
-        <main>
-          <section className="section">
-            <div className="container is-max-desktop is-flex is-flex-direction-column">
-              <h2 id="characters" className="jump-anchor-header-padding title">
-                <Link to={`#characters`} className="has-text-black">
-                  キャラクター一覧
-                </Link>
-              </h2>
-              <div className="columns is-multiline is-centered">
-                {characterKeys.map((characterKey, index) => (
-                  <CharacterCard key={index} characterKey={characterKey} />
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="section">
-            <div className="container is-max-desktop is-flex is-flex-direction-column">
-              <h2 id="oss" className="jump-anchor-header-padding title">
-                <Link to={`#oss`} className="has-text-black">
-                  オープンソース
-                </Link>
-              </h2>
-              <p className="is-size-5">
-                VOICEVOX は OSS（オープンソース・ソフトウェア）版 VOICEVOX
-                をもとに構築されています。
-              </p>
-              <p className="is-size-5">
-                製品版と OSS 版の違いやモジュール構成は&nbsp;
-                <a
-                  href="https://github.com/VOICEVOX/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="has-text-weight-bold is-underlined"
-                >
-                  VOICEVOX の全体構成
-                </a>
-                &nbsp;をご参照ください。
-              </p>
-              <p className="is-size-5">
-                ソフトウェア部分は Electron + Vue 、音声合成エンジン部分は
-                Python + FastAPI です。
-              </p>
-              <p className="is-size-5">
-                追加したい・改善したい機能があれば、ぜひ開発にご参加ください。
-              </p>
-              <div className="buttons mt-3">
-                <a
-                  className="button is-outlined"
-                  href="https://github.com/VOICEVOX/voicevox"
-                  target="_blank"
-                  rel="noreferrer"
-                  type="button"
-                  role={"button"}
-                >
-                  <span className="icon">
-                    <FontAwesomeIcon icon={faGithub} />
-                  </span>
-                  <span>VOICEVOX エディター</span>
-                </a>
-                <a
-                  className="button is-outlined"
-                  href="https://github.com/VOICEVOX/voicevox_engine"
-                  target="_blank"
-                  rel="noreferrer"
-                  type="button"
-                  role={"button"}
-                >
-                  <span className="icon">
-                    <FontAwesomeIcon icon={faGithub} />
-                  </span>
-                  <span>VOICEVOX エンジン</span>
-                </a>
-              </div>
-            </div>
-          </section>
-
-          <section className="section">
-            <div className="container is-max-desktop is-flex is-flex-direction-column">
-              <h2
-                id="core_library"
-                className="jump-anchor-header-padding title"
-              >
-                <Link to={`#core_library`} className="has-text-black">
-                  コアライブラリ
-                </Link>
-              </h2>
-              <p className="is-size-5">
-                VOICEVOXの音声合成をアプリケーションやサービスに組み込める、VOICEVOXのコアライブラリを配布しています。
-              </p>
-              <p className="is-size-5">
-                詳しくは&nbsp;
-                <a
-                  href="https://github.com/VOICEVOX/voicevox_core"
-                  className="has-text-weight-bold is-underlined"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  VOICEVOX CORE
-                </a>
-                &nbsp;をご参照ください。
-              </p>
-            </div>
-          </section>
-
-          <section className="section">
-            <div className="container is-max-desktop is-flex is-flex-direction-column">
-              <h2 id="link" className="jump-anchor-header-padding title">
-                <Link to={`#link`} className="has-text-black">
-                  リンク
-                </Link>
-              </h2>
-              <ul className="is-size-5">
-                <li>
-                  <Link
-                    to={"/term/"}
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    利用規約
+            <section className="section">
+              <div className="container is-max-desktop is-flex is-flex-direction-column">
+                <h2 id="oss" className="jump-anchor-header-padding title">
+                  <Link to={`#oss`} className="has-text-black">
+                    オープンソース
                   </Link>
-                </li>
-                <li>
-                  <Link
-                    to={"/how_to_use/"}
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    使い方
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to={"/qa/"}
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    Q&amp;A
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to={"/dormitory/"}
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    ボイボ寮
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to={"/update_history/"}
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    変更履歴
-                  </Link>
-                </li>
-                <li>
+                </h2>
+                <p className="is-size-5">
+                  VOICEVOX は OSS（オープンソース・ソフトウェア）版 VOICEVOX
+                  をもとに構築されています。
+                </p>
+                <p className="is-size-5">
+                  製品版と OSS 版の違いやモジュール構成は&nbsp;
                   <a
-                    href="https://hiho.fanbox.cc/"
-                    target={"_blank"}
-                    rel={"noreferrer"}
+                    href="https://github.com/VOICEVOX/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md"
+                    target="_blank"
+                    rel="noreferrer"
                     className="has-text-weight-bold is-underlined"
                   >
-                    pixivFANBOX
+                    VOICEVOX の全体構成
                   </a>
-                </li>
-              </ul>
-            </div>
-          </section>
-        </main>
-      </div>
-      <ModalReadmeLibrary
-        hide={() => setShowingLibraryReadmeModalCharacterKey(undefined)}
-        {...(showingLibraryReadmeModalCharacterKey != undefined
-          ? {
-              isActive: true,
-              characterKey: showingLibraryReadmeModalCharacterKey,
-            }
-          : {
-              isActive: false,
-              characterKey: undefined,
-            })}
-      />
-    </>
-  )
-}
+                  &nbsp;をご参照ください。
+                </p>
+                <p className="is-size-5">
+                  ソフトウェア部分は Electron + Vue 、音声合成エンジン部分は
+                  Python + FastAPI です。
+                </p>
+                <p className="is-size-5">
+                  追加したい・改善したい機能があれば、ぜひ開発にご参加ください。
+                </p>
+                <div className="buttons mt-3">
+                  <a
+                    className="button is-outlined"
+                    href="https://github.com/VOICEVOX/voicevox"
+                    target="_blank"
+                    rel="noreferrer"
+                    type="button"
+                    role={"button"}
+                  >
+                    <span className="icon">
+                      <FontAwesomeIcon icon={faGithub} />
+                    </span>
+                    <span>VOICEVOX エディター</span>
+                  </a>
+                  <a
+                    className="button is-outlined"
+                    href="https://github.com/VOICEVOX/voicevox_engine"
+                    target="_blank"
+                    rel="noreferrer"
+                    type="button"
+                    role={"button"}
+                  >
+                    <span className="icon">
+                      <FontAwesomeIcon icon={faGithub} />
+                    </span>
+                    <span>VOICEVOX エンジン</span>
+                  </a>
+                </div>
+              </div>
+            </section>
 
-export default () => {
+            <section className="section">
+              <div className="container is-max-desktop is-flex is-flex-direction-column">
+                <h2
+                  id="core_library"
+                  className="jump-anchor-header-padding title"
+                >
+                  <Link to={`#core_library`} className="has-text-black">
+                    コアライブラリ
+                  </Link>
+                </h2>
+                <p className="is-size-5">
+                  VOICEVOXの音声合成をアプリケーションやサービスに組み込める、VOICEVOXのコアライブラリを配布しています。
+                </p>
+                <p className="is-size-5">
+                  詳しくは&nbsp;
+                  <a
+                    href="https://github.com/VOICEVOX/voicevox_core"
+                    className="has-text-weight-bold is-underlined"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    VOICEVOX CORE
+                  </a>
+                  &nbsp;をご参照ください。
+                </p>
+              </div>
+            </section>
+
+            <section className="section">
+              <div className="container is-max-desktop is-flex is-flex-direction-column">
+                <h2 id="link" className="jump-anchor-header-padding title">
+                  <Link to={`#link`} className="has-text-black">
+                    リンク
+                  </Link>
+                </h2>
+                <ul className="is-size-5">
+                  <li>
+                    <Link
+                      to={"/term/"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      利用規約
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to={"/how_to_use/"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      使い方
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to={"/qa/"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      Q&amp;A
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to={"/dormitory/"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      ボイボ寮
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to={"/update_history/"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      変更履歴
+                    </Link>
+                  </li>
+                  <li>
+                    <a
+                      href="https://hiho.fanbox.cc/"
+                      target={"_blank"}
+                      rel={"noreferrer"}
+                      className="has-text-weight-bold is-underlined"
+                    >
+                      pixivFANBOX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </section>
+          </main>
+        </div>
+        <ModalReadmeLibrary
+          hide={() => setShowingLibraryReadmeModalCharacterKey(undefined)}
+          {...(showingLibraryReadmeModalCharacterKey != undefined
+            ? {
+                isActive: true,
+                characterKey: showingLibraryReadmeModalCharacterKey,
+              }
+            : {
+                isActive: false,
+                characterKey: undefined,
+              })}
+        />
+      </>
+    )
+  }
+)
+
+export default React.memo(() => {
   const [showingHeader, setShowingHeader] = useState(false)
   return (
     <Page showingHeader={showingHeader} showingHeaderOnTop={false}>
       <Main setShowingHeader={setShowingHeader} />
     </Page>
   )
-}
+})


### PR DESCRIPTION
## 内容

メインページで、スクロールしていったり音声を再生しようとしたりするとなぜか再レンダリングが入っていました。
再レンダリングは早いのでたいてい問題なかったのですが、ヘッダーがちらついたり、音声再生ボタンがまたloadingに戻ったりしていました。

React.memoを使ってコンポーネントをメモ化したりして問題を低減しました。

## その他

なぜReact.memoがデフォルトでONじゃないのか･･･。
