### PR TITLE
ボイボ寮のキャラ個別ページの下にあるキャラ一覧リンクボタンをファーストビューに表示にする

### DIFF
--- a/src/pages/dormitory/{Character.characterId}.tsx
+++ b/src/pages/dormitory/{Character.characterId}.tsx
@@ -2,7 +2,7 @@ import { faHome } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Link, navigate, PageProps } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
-import React, { useMemo, useState } from "react"
+import React, { useMemo, useState, useEffect } from "react"
 import { Page } from "../../components/page"
 import PlayButton from "../../components/playButton"
 import Seo from "../../components/seo"
@@ -124,19 +124,30 @@ export default ({
     }
   }
 
-  // pcのみキャラ一覧とダウンロードページへのリンクボタンをファーストビューに表示する
-  const responsiveButtonGroupStyle = navigator.userAgent.match(
-    /iPhone|Android.+Mobile/
-  )
+  function useMediaQuery(query: string) {
+    const [matches, setMatches] = useState(window.matchMedia(query).matches)
+
+    useEffect(() => {
+      const media = window.matchMedia(query)
+      const listener = () => setMatches(media.matches)
+      media.addEventListener("change", listener)
+      return () => media.removeEventListener("change", listener)
+    }, [query])
+
+    return matches
+  }
+
+  // 1180px以下の場合はボタンをキャラクター紹介欄の下に表示する
+  // (ウインドウ幅の変動によって、ボタンが隠れ始めるタイミングが1180pxだった)
+  const isMobile = useMediaQuery("(max-width: 1180px)")
+  const responsiveButtonGroupStyle = isMobile
     ? {}
     : {
         display: "inline-flex",
         flexDirection: "column" as const,
         position: "absolute" as const,
         left: "100%",
-        top: "70%",
-        height: "25%",
-        width: "25%",
+        bottom: "25%",
       }
 
   return (


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

https://github.com/VOICEVOX/voicevox_blog/issues/169 関連のプルリクエストです。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref #169

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

![Screenshot from 2023-12-08 16-41-35](https://github.com/VOICEVOX/voicevox_blog/assets/100256521/66d63834-a266-4a4a-beac-5805baeb29df)


## その他

