### PR TITLE
ダウンロードボタンの近くに利用規約ボタンを追加

### DIFF
--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -181,13 +181,9 @@ export const DownloadModal: React.FC<{
         </section>
 
         <footer className="modal-card-foot is-justify-content-flex-end">
-          <a
-            className="button is-normal is-rounded"
-            href="https://voicevox.hiroshiba.jp/term/"
-            target="_blank"
-          >
-            <span>VOICEVOX 利用規約</span>
-          </a>
+          <Link to="/term/" className="button">
+            <span>利用規約</span>
+          </Link>
           <a
             href={
               downloadUrls[selectedOs][selectedMode]?.[selectedPackage]?.url

--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -182,6 +182,13 @@ export const DownloadModal: React.FC<{
 
         <footer className="modal-card-foot is-justify-content-flex-end">
           <a
+            className="button is-normal is-rounded"
+            href="https://voicevox.hiroshiba.jp/term/"
+            target="_blank"
+          >
+            <span>VOICEVOX 利用規約</span>
+          </a>
+          <a
             href={
               downloadUrls[selectedOs][selectedMode]?.[selectedPackage]?.url
             }

--- a/src/components/softwareFeature.tsx
+++ b/src/components/softwareFeature.tsx
@@ -55,6 +55,13 @@ export default ({
         <span className="has-text-weight-semibold">ダウンロード</span>
       </a>
       <p className="is-align-self-center is-size-6">Version {APP_VERSION}</p>
+      <a
+        className="button is-align-self-center mt-5 is-normal is-large is-rounded"
+        href="https://voicevox.hiroshiba.jp/term/"
+        target="_blank"
+      >
+        <span>VOICEVOX 利用規約</span>
+      </a>
     </div>
   )
 }

--- a/src/components/softwareFeature.tsx
+++ b/src/components/softwareFeature.tsx
@@ -55,13 +55,6 @@ export default ({
         <span className="has-text-weight-semibold">ダウンロード</span>
       </a>
       <p className="is-align-self-center is-size-6">Version {APP_VERSION}</p>
-      <a
-        className="button is-align-self-center mt-5 is-normal is-large is-rounded"
-        href="https://voicevox.hiroshiba.jp/term/"
-        target="_blank"
-      >
-        <span>VOICEVOX 利用規約</span>
-      </a>
     </div>
   )
 }


### PR DESCRIPTION
## 内容

トップページのダウンロードボタンの下部に利用規約ページに遷移するボタンを追加

## 関連 Issue

close #181 

## スクリーンショット・動画など

![image](https://github.com/VOICEVOX/voicevox_blog/assets/40142697/bc2000a1-d261-4cd6-880d-5a8f7b72432d)
<img width="327" alt="スクリーンショット 2024-02-13 11 42 02" src="https://github.com/VOICEVOX/voicevox_blog/assets/40142697/c1d44d22-6e55-4c15-af26-df8711e48203">

## その他