### PR TITLE
OSSに関する案内をソングページに追加

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -869,10 +869,6 @@ $dropdown-item-active-background-color: $primary;
       }
     }
   }
-
-  .explain-humming {
-    @extend .is-max-widescreen;
-  }
 }
 
 .markdown {

--- a/src/components/ossGuidance.tsx
+++ b/src/components/ossGuidance.tsx
@@ -1,0 +1,77 @@
+import { faGithub } from "@fortawesome/free-brands-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Link } from "gatsby"
+import React, { CSSProperties } from "react"
+
+export const OssGuidance: React.FC<{
+  className?: string
+  isDark: boolean // Nemoのページかどうか
+}> = ({ className, isDark }) => {
+  return (
+    <section className="section">
+      <div
+        className={`${className} container is-max-desktop is-flex is-flex-direction-column`}
+      >
+        <h2 id="oss" className="jump-anchor-header-padding title">
+          <Link
+            to={`#oss`}
+            className={!isDark ? "has-text-black" : "has-text-white"}
+          >
+            オープンソース
+          </Link>
+        </h2>
+        <p className="is-size-5">
+          VOICEVOX は OSS（オープンソース・ソフトウェア）版 VOICEVOX
+          をもとに構築されています。
+        </p>
+        <p className="is-size-5">
+          製品版と OSS 版の違いやモジュール構成は&nbsp;
+          <a
+            href="https://github.com/VOICEVOX/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md"
+            target="_blank"
+            rel="noreferrer"
+            className="has-text-weight-bold is-underlined"
+          >
+            VOICEVOX の全体構成
+          </a>
+          &nbsp;をご参照ください。
+        </p>
+        <p className="is-size-5">
+          ソフトウェア部分は Electron + Vue 、音声合成エンジン部分は Python +
+          FastAPI です。
+        </p>
+        <p className="is-size-5">
+          追加したい・改善したい機能があれば、ぜひ開発にご参加ください。
+        </p>
+        <div className="buttons mt-3">
+          <a
+            className={`button ${!isDark ? "is-outlined" : "is-dark"}`}
+            href="https://github.com/VOICEVOX/voicevox"
+            target="_blank"
+            rel="noreferrer"
+            type="button"
+            role={"button"}
+          >
+            <span className="icon">
+              <FontAwesomeIcon icon={faGithub} />
+            </span>
+            <span>VOICEVOX エディター</span>
+          </a>
+          <a
+            className={`button ${!isDark ? "is-outlined" : "is-dark"}`}
+            href="https://github.com/VOICEVOX/voicevox_engine"
+            target="_blank"
+            rel="noreferrer"
+            type="button"
+            role={"button"}
+          >
+            <span className="icon">
+              <FontAwesomeIcon icon={faGithub} />
+            </span>
+            <span>VOICEVOX エンジン</span>
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/ossGuidance.tsx
+++ b/src/components/ossGuidance.tsx
@@ -1,11 +1,11 @@
 import { faGithub } from "@fortawesome/free-brands-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Link } from "gatsby"
-import React, { CSSProperties } from "react"
+import React from "react"
 
-export const OssGuidance: React.FC<{
+export const OssGuidanceSection: React.FC<{
   className?: string
-  isDark: boolean // Nemoのページかどうか
+  isDark: boolean // Nemoやソングのページかどうか
 }> = ({ className, isDark }) => {
   return (
     <section className="section">

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -4,7 +4,7 @@ import React from "react"
 
 export const VVFooter: React.FC<{
   privacyPolicyShower: () => void
-  isDark: boolean // Nemoのページかどうか
+  isDark: boolean // Nemoやソングのページかどうか
 }> = ({ privacyPolicyShower, isDark }) => (
   <>
     <div className={`container is-flex is-justify-content-center`}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import { faGithub } from "@fortawesome/free-brands-svg-icons"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Link } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
 import React, { useContext, useEffect, useRef, useState } from "react"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import React, { useContext, useEffect, useRef, useState } from "react"
 import AudioSample from "../components/audioSample"
 import "../components/layout.scss"
 import ModalReadmeLibrary from "../components/modalReadmeLibrary"
+import { OssGuidanceSection } from "../components/ossGuidance"
 import { Page } from "../components/page"
 import Seo from "../components/seo"
 import SoftwareFeature from "../components/softwareFeature"
@@ -15,7 +16,6 @@ import Logo from "../images/logo.svg"
 import landingMovie from "../movies/landing.mp4"
 import { CharacterInfo, CharacterKey } from "../types/dormitoryCharacter"
 import { getProductPageUrl } from "../urls"
-import { OssGuidance } from "../components/ossGuidance"
 
 // キャラクター表示
 const CharacterCard = React.memo(
@@ -202,7 +202,7 @@ const Main = React.memo(
               </div>
             </section>
 
-            <OssGuidance isDark={false} />
+            <OssGuidanceSection isDark={false} />
 
             <section className="section">
               <div className="container is-max-desktop is-flex is-flex-direction-column">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,6 +17,7 @@ import Logo from "../images/logo.svg"
 import landingMovie from "../movies/landing.mp4"
 import { CharacterInfo, CharacterKey } from "../types/dormitoryCharacter"
 import { getProductPageUrl } from "../urls"
+import { OssGuidance } from "../components/ossGuidance"
 
 // キャラクター表示
 const CharacterCard = React.memo(
@@ -203,66 +204,7 @@ const Main = React.memo(
               </div>
             </section>
 
-            <section className="section">
-              <div className="container is-max-desktop is-flex is-flex-direction-column">
-                <h2 id="oss" className="jump-anchor-header-padding title">
-                  <Link to={`#oss`} className="has-text-black">
-                    オープンソース
-                  </Link>
-                </h2>
-                <p className="is-size-5">
-                  VOICEVOX は OSS（オープンソース・ソフトウェア）版 VOICEVOX
-                  をもとに構築されています。
-                </p>
-                <p className="is-size-5">
-                  製品版と OSS 版の違いやモジュール構成は&nbsp;
-                  <a
-                    href="https://github.com/VOICEVOX/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="has-text-weight-bold is-underlined"
-                  >
-                    VOICEVOX の全体構成
-                  </a>
-                  &nbsp;をご参照ください。
-                </p>
-                <p className="is-size-5">
-                  ソフトウェア部分は Electron + Vue 、音声合成エンジン部分は
-                  Python + FastAPI です。
-                </p>
-                <p className="is-size-5">
-                  追加したい・改善したい機能があれば、ぜひ開発にご参加ください。
-                </p>
-                <div className="buttons mt-3">
-                  <a
-                    className="button is-outlined"
-                    href="https://github.com/VOICEVOX/voicevox"
-                    target="_blank"
-                    rel="noreferrer"
-                    type="button"
-                    role={"button"}
-                  >
-                    <span className="icon">
-                      <FontAwesomeIcon icon={faGithub} />
-                    </span>
-                    <span>VOICEVOX エディター</span>
-                  </a>
-                  <a
-                    className="button is-outlined"
-                    href="https://github.com/VOICEVOX/voicevox_engine"
-                    target="_blank"
-                    rel="noreferrer"
-                    type="button"
-                    role={"button"}
-                  >
-                    <span className="icon">
-                      <FontAwesomeIcon icon={faGithub} />
-                    </span>
-                    <span>VOICEVOX エンジン</span>
-                  </a>
-                </div>
-              </div>
-            </section>
+            <OssGuidance isDark={false} />
 
             <section className="section">
               <div className="container is-max-desktop is-flex is-flex-direction-column">

--- a/src/pages/song/index.tsx
+++ b/src/pages/song/index.tsx
@@ -17,6 +17,7 @@ import { useDetailedCharacterInfo } from "../../hooks/useDetailedCharacterInfo"
 import shareThumb from "../../images/song/share-thumb.png"
 import { CharacterInfo, CharacterKey } from "../../types/dormitoryCharacter"
 import { getProductPageUrl } from "../../urls"
+import { OssGuidance } from "../../components/ossGuidance"
 
 // キャラクターごとのカード表示
 const CharacterCard = React.memo(
@@ -298,7 +299,7 @@ export default () => {
             </div>
           </div>
 
-          <div className="container explain-humming">
+          <div className="container is-max-desktop">
             <h2 className="title">ハミングとは？</h2>
             <p>
               喋り声のデータを用いて音声ライブラリを作成し、
@@ -309,7 +310,7 @@ export default () => {
           </div>
         </section>
 
-        {/* TODO: トーク側にあるOSSとかの案内を追加 */}
+        <OssGuidance isDark={true} />
       </main>
     </Page>
   )

--- a/src/pages/song/index.tsx
+++ b/src/pages/song/index.tsx
@@ -11,13 +11,13 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Link } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
+import { OssGuidanceSection } from "../../components/ossGuidance"
 import PlayButton from "../../components/playButton"
 import { CharacterContext, GlobalContext } from "../../contexts/context"
 import { useDetailedCharacterInfo } from "../../hooks/useDetailedCharacterInfo"
 import shareThumb from "../../images/song/share-thumb.png"
 import { CharacterInfo, CharacterKey } from "../../types/dormitoryCharacter"
 import { getProductPageUrl } from "../../urls"
-import { OssGuidance } from "../../components/ossGuidance"
 
 // キャラクターごとのカード表示
 const CharacterCard = React.memo(
@@ -298,7 +298,9 @@ export default () => {
               ))}
             </div>
           </div>
+        </section>
 
+        <section className="section">
           <div className="container is-max-desktop">
             <h2 className="title">ハミングとは？</h2>
             <p>
@@ -310,7 +312,7 @@ export default () => {
           </div>
         </section>
 
-        <OssGuidance isDark={true} />
+        <OssGuidanceSection isDark={true} />
       </main>
     </Page>
   )


### PR DESCRIPTION
## 内容

- OSSへの案内部分をコンポーネントへ
- ソングページ下部にOSSへの案内を追加
- ソングページのハミングの説明の幅を調整

## 関連 Issue

close #204 

## スクリーンショット・動画など

![ソング](https://github.com/VOICEVOX/voicevox_blog/assets/40142697/fc6b8bb4-3603-4fdb-b1ae-4500c0ea6666)
<img width="320" alt="ソング_スマホ" src="https://github.com/VOICEVOX/voicevox_blog/assets/40142697/184d4e19-9529-461a-bdef-5d11dfa4ef1b">

## その他
