### PR TITLE
VOICEVOXデフォルトエンジンの更新情報の構造を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ curl -s "$editor_url/public/qAndA.md" > src/markdowns/qAndA.md
 curl -s "$editor_url/public/updateInfos.json" > src/data/updateInfos.json
 
 # デフォルトエンジンの更新情報
-npm run latestDefaultEngineInfos
+npm run generateLatestDefaultEngineInfos
 ```
 
 ## 音量に関して

--- a/src/data/latestDefaultEngineInfos.json
+++ b/src/data/latestDefaultEngineInfos.json
@@ -1,81 +1,83 @@
 {
   "formatVersion": 1,
-  "windows": {
-    "x64": {
-      "CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-windows-cpu-0.20.0.vvpp",
-            "name": "voicevox_engine-windows-cpu-0.20.0.vvpp",
-            "size": 1374659234
-          }
-        ]
-      },
-      "GPU/CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-windows-directml-0.20.0.vvpp",
-            "name": "voicevox_engine-windows-directml-0.20.0.vvpp",
-            "size": 1382829369
-          }
-        ]
-      }
-    }
-  },
-  "macos": {
-    "x64": {
-      "CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-macos-x64-0.20.0.001.vvppp",
-            "name": "voicevox_engine-macos-x64-0.20.0.001.vvppp",
-            "size": 1382766014
-          }
-        ]
+  "074fc39e-678b-4c13-8916-ffca8d505d1d": {
+    "windows": {
+      "x64": {
+        "CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-windows-cpu-0.20.0.vvpp",
+              "name": "voicevox_engine-windows-cpu-0.20.0.vvpp",
+              "size": 1374659234
+            }
+          ]
+        },
+        "GPU/CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-windows-directml-0.20.0.vvpp",
+              "name": "voicevox_engine-windows-directml-0.20.0.vvpp",
+              "size": 1382829369
+            }
+          ]
+        }
       }
     },
-    "arm64": {
-      "CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-macos-arm64-0.20.0.001.vvppp",
-            "name": "voicevox_engine-macos-arm64-0.20.0.001.vvppp",
-            "size": 1375008115
-          }
-        ]
-      }
-    }
-  },
-  "linux": {
-    "x64": {
-      "CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-cpu-0.20.0.vvpp",
-            "name": "voicevox_engine-linux-cpu-0.20.0.vvpp",
-            "size": 1399437028
-          }
-        ]
+    "macos": {
+      "x64": {
+        "CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-macos-x64-0.20.0.001.vvppp",
+              "name": "voicevox_engine-macos-x64-0.20.0.001.vvppp",
+              "size": 1382766014
+            }
+          ]
+        }
       },
-      "GPU/CPU": {
-        "version": "0.20.0",
-        "packages": [
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-nvidia-0.20.0.001.vvppp",
-            "name": "voicevox_engine-linux-nvidia-0.20.0.001.vvppp",
-            "size": 1992294400
-          },
-          {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-nvidia-0.20.0.002.vvppp",
-            "name": "voicevox_engine-linux-nvidia-0.20.0.002.vvppp",
-            "size": 645130316
-          }
-        ]
+      "arm64": {
+        "CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-macos-arm64-0.20.0.001.vvppp",
+              "name": "voicevox_engine-macos-arm64-0.20.0.001.vvppp",
+              "size": 1375008115
+            }
+          ]
+        }
+      }
+    },
+    "linux": {
+      "x64": {
+        "CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-cpu-0.20.0.vvpp",
+              "name": "voicevox_engine-linux-cpu-0.20.0.vvpp",
+              "size": 1399437028
+            }
+          ]
+        },
+        "GPU/CPU": {
+          "version": "0.20.0",
+          "packages": [
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-nvidia-0.20.0.001.vvppp",
+              "name": "voicevox_engine-linux-nvidia-0.20.0.001.vvppp",
+              "size": 1992294400
+            },
+            {
+              "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.20.0/voicevox_engine-linux-nvidia-0.20.0.002.vvppp",
+              "name": "voicevox_engine-linux-nvidia-0.20.0.002.vvppp",
+              "size": 645130316
+            }
+          ]
+        }
       }
     }
   }

--- a/src/generateLatestDefaultEngineInfos.ts
+++ b/src/generateLatestDefaultEngineInfos.ts
@@ -12,52 +12,54 @@ jsonファイルの形式は以下の通り
   //[number] ファイル構造バージョン（仕様変更毎にインクリメントされる）
   "formatVersion": 1,
 
-  // Windowsの情報
-  "windows": {
-    "x64": {
-      "CPU": {
-        //[string] バージョン
-        "version": "x.x.x",
+  // エンジンの情報
+  "00000000-0000-0000-0000-000000000001": {
+    // Windowsの情報
+    "windows": {
+      "x64": {
+        "CPU": {
+          //[string] バージョン
+          "version": "x.x.x",
 
-        // vvppやvvpppの情報
-        "packages": [
-          {
-            //[string] ダウンロードURL
-            "url": "https://example.com/",
+          // vvppやvvpppの情報
+          "packages": [
+            {
+              //[string] ダウンロードURL
+              "url": "https://example.com/",
 
-            //[string] ファイル名
-            "name": "example.vvpp",
+              //[string] ファイル名
+              "name": "example.vvpp",
 
-            //[number] バイト数
-            "size": 123456,
+              //[number] バイト数
+              "size": 123456,
 
-            //[string(Optional)] ハッシュ値
-            "hash": "xxxxxxx",
-          },
-          //...
-        ]
-      },
-      "GPU/CPU": {}
-    }
-  },
-
-  "macos": {
-    "x64": {
-      "CPU": {}
+              //[string(Optional)] ハッシュ値
+              "hash": "xxxxxxx",
+            },
+            //...
+          ]
+        },
+        "GPU/CPU": {}
+      }
     },
-    "arm64": {
-      "CPU": {}
-    }
-  },
 
-  "linux": {
-    "x64": {
-      "CPU": {},
-      "GPU/CPU": {}
+    "macos": {
+      "x64": {
+        "CPU": {}
+      },
+      "arm64": {
+        "CPU": {}
+      }
+    },
+
+    "linux": {
+      "x64": {
+        "CPU": {},
+        "GPU/CPU": {}
+      }
     }
   }
 }
-
 */
 
 import fs from "fs"
@@ -77,6 +79,7 @@ const argv = yargs(hideBin(process.argv))
 
 const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/VOICEVOX/voicevox_engine/releases"
+const ENGINE_ID = "074fc39e-678b-4c13-8916-ffca8d505d1d"
 
 /** 対応するvvpp.txtの名前 */
 function getVvppTxtName(version: string) {
@@ -107,6 +110,7 @@ function getVvppTxtName(version: string) {
 async function main() {
   const output = {
     formatVersion: 1,
+    [ENGINE_ID]: {},
   }
 
   let releases = await (await fetch(GITHUB_RELEASES_URL)).json()
@@ -168,9 +172,9 @@ async function main() {
     })
 
     // 記録
-    output[os] = output[os] || {}
-    output[os][arch] = output[os][arch] || {}
-    output[os][arch][device] = {
+    output[ENGINE_ID][os] = output[ENGINE_ID][os] || {}
+    output[ENGINE_ID][os][arch] = output[ENGINE_ID][os][arch] || {}
+    output[ENGINE_ID][os][arch][device] = {
       version,
       packages,
     }


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_blog/pull/218

の続きタスクです。

デフォルトエンジンは複数設定できるようになっているので、こちらの更新情報も複数設置できるようにしておく必要があることに気づきました。
ということでルート直下にエンジンIDを設定できるようにし、そのエンジン ID ごとにオブジェクトを1つ持てるようにしました。

データ構造的には階層が1つ増えただけです。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_blog/pull/218
- https://github.com/VOICEVOX/voicevox/pull/2270


## その他
