### PR TITLE
Add: ボイボ寮側のキャラページの呼び方に不明時の表示を追加

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -1254,6 +1254,10 @@ $dropdown-item-active-background-color: $primary;
                   border-style: solid;
                   border-radius: 8px;
                   text-align: center;
+
+                  &.unknown {
+                    color: gray;
+                  }
                 }
               }
             }

--- a/src/pages/dormitory/{Character.characterId}.tsx
+++ b/src/pages/dormitory/{Character.characterId}.tsx
@@ -78,20 +78,28 @@ export default ({
         <div className="column description-call-line">
           <div className="description-call-one">
             <span
-              className="description-call-text"
+              className={`description-call-text ${
+                callNameInfos[selectedCharacterKey][targetCharacterKey]
+                  ? ""
+                  : "unknown"
+              }`}
               style={{ borderColor: characterInfo.color }}
             >
-              {callNameInfos[selectedCharacterKey][targetCharacterKey]}
+              {callNameInfos[selectedCharacterKey][targetCharacterKey] || "？"}
             </span>
             <Arrow leftOrRight="right" />
           </div>
           <div className="description-call-one">
             <Arrow leftOrRight="left" />
             <span
-              className="description-call-text"
+              className={`description-call-text ${
+                callNameInfos[targetCharacterKey][selectedCharacterKey]
+                  ? ""
+                  : "unknown"
+              }`}
               style={{ borderColor: characterInfos[targetCharacterKey].color }}
             >
-              {callNameInfos[targetCharacterKey][selectedCharacterKey]}
+              {callNameInfos[targetCharacterKey][selectedCharacterKey] || "？"}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## 内容

タイトル通りです。

## 関連 Issue

（なし）

## スクリーンショット・動画など

![image](https://github.com/user-attachments/assets/7ab7673d-320b-40a3-b6b8-394e5f5d5bfc)

## その他

（なし）