### PR TITLE
Fix: ダウンロードダイアログのOS変更時の挙動を修正、OSによって初期選択が変わるように

### DIFF
--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -13,10 +13,7 @@ const modeAvailables: Record<OsType, ModeType[]> = {
   Linux: ["GPU / CPU", "CPU"],
 }
 
-const packageAvailables: Record<
-  OsType,
-  Partial<Record<ModeType, PackageType[]>>
-> = {
+const packageAvailables = {
   Windows: {
     "GPU / CPU": ["インストーラー", "Zip"],
     CPU: ["インストーラー", "Zip"],
@@ -26,7 +23,7 @@ const packageAvailables: Record<
     "CPU (Apple)": ["インストーラー", "Zip"],
   },
   Linux: { "GPU / CPU": ["インストーラー"], CPU: ["インストーラー", "tar.gz"] },
-}
+} as const satisfies Record<OsType, Partial<Record<ModeType, PackageType[]>>>
 
 export const DownloadModal: React.FC<{
   isActive: boolean
@@ -136,6 +133,12 @@ export const DownloadModal: React.FC<{
     ? selectedPackage
     : packageAvailables[selectedOs][selectedOrDefaultMode]![0]
 
+  const onSelectedOsChange = (os: OsType) => {
+    setSelectedOs(os)
+    setSelectedMode(modeAvailables[os][0])
+    setSelectedPackage(packageAvailables[os][modeAvailables[os][0]][0])
+  }
+
   return (
     <div
       className={"modal-download modal" + (props.isActive ? " is-active" : "")}
@@ -160,7 +163,7 @@ export const DownloadModal: React.FC<{
           <DownloadModalSelecter
             label="OS"
             selected={selectedOs}
-            setSelected={setSelectedOs}
+            setSelected={onSelectedOsChange}
             candidates={["Windows", "Mac", "Linux"]}
           />
 

--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -136,11 +136,11 @@ export const DownloadModal: React.FC<{
   useEffect(() => {
     const userAgent = window.navigator.userAgent
     if (userAgent.includes("Windows")) {
-      setSelectedOs("Windows")
+      selectOs("Windows")
     } else if (userAgent.includes("Mac")) {
-      setSelectedOs("Mac")
+      selectOs("Mac")
     } else if (userAgent.includes("Linux")) {
-      setSelectedOs("Linux")
+      selectOs("Linux")
     }
   }, [])
 

--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -133,10 +133,21 @@ export const DownloadModal: React.FC<{
     ? selectedPackage
     : packageAvailables[selectedOs][selectedOrDefaultMode]![0]
 
-  const onSelectedOsChange = (os: OsType) => {
+  const selectOs = (os: OsType) => {
     setSelectedOs(os)
-    setSelectedMode(modeAvailables[os][0])
-    setSelectedPackage(packageAvailables[os][modeAvailables[os][0]][0])
+    // 変更先のOSで選択できないモードの場合、最初のモードを選択する
+    selectMode(
+      modeAvailables[os].includes(selectedMode)
+        ? selectedMode
+        : modeAvailables[os][0],
+      os
+    )
+  }
+  const selectMode = (mode: ModeType, os?: OsType) => {
+    setSelectedMode(mode)
+    if (!packageAvailables[os ?? selectedOs][mode]!.includes(selectedPackage)) {
+      setSelectedPackage(packageAvailables[os ?? selectedOs][mode]![0])
+    }
   }
 
   return (
@@ -163,7 +174,7 @@ export const DownloadModal: React.FC<{
           <DownloadModalSelecter
             label="OS"
             selected={selectedOs}
-            setSelected={onSelectedOsChange}
+            setSelected={selectOs}
             candidates={["Windows", "Mac", "Linux"]}
           />
 
@@ -172,7 +183,7 @@ export const DownloadModal: React.FC<{
           <DownloadModalSelecter
             label="対応モード"
             selected={selectedOrDefaultMode}
-            setSelected={setSelectedMode}
+            setSelected={selectMode}
             candidates={modeAvailables[selectedOs]}
           />
           <p className="has-text-centered is-size-7">

--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -148,16 +148,16 @@ export const DownloadModal: React.FC<{
     setSelectedOs(os)
     // 変更先のOSで選択できないモードの場合、最初のモードを選択する
     selectMode(
+      os,
       modeAvailables[os].includes(selectedMode)
         ? selectedMode
-        : modeAvailables[os][0],
-      os
+        : modeAvailables[os][0]
     )
   }
-  const selectMode = (mode: ModeType, os?: OsType) => {
+  const selectMode = (os: OsType, mode: ModeType) => {
     setSelectedMode(mode)
-    if (!packageAvailables[os ?? selectedOs][mode]!.includes(selectedPackage)) {
-      setSelectedPackage(packageAvailables[os ?? selectedOs][mode]![0])
+    if (!packageAvailables[os][mode]!.includes(selectedPackage)) {
+      setSelectedPackage(packageAvailables[os][mode]![0])
     }
   }
 
@@ -194,7 +194,7 @@ export const DownloadModal: React.FC<{
           <DownloadModalSelecter
             label="対応モード"
             selected={selectedOrDefaultMode}
-            setSelected={selectMode}
+            setSelected={mode => selectMode(selectedOs, mode)}
             candidates={modeAvailables[selectedOs]}
           />
           <p className="has-text-centered is-size-7">

--- a/src/components/downloadModal.tsx
+++ b/src/components/downloadModal.tsx
@@ -1,5 +1,5 @@
 import { Link, graphql, useStaticQuery } from "gatsby"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { APP_VERSION } from "../constants"
 import DownloadModalSelecter from "./downloadModalSelecter"
 
@@ -132,6 +132,17 @@ export const DownloadModal: React.FC<{
   ]!.includes(selectedPackage)
     ? selectedPackage
     : packageAvailables[selectedOs][selectedOrDefaultMode]![0]
+
+  useEffect(() => {
+    const userAgent = window.navigator.userAgent
+    if (userAgent.includes("Windows")) {
+      setSelectedOs("Windows")
+    } else if (userAgent.includes("Mac")) {
+      setSelectedOs("Mac")
+    } else if (userAgent.includes("Linux")) {
+      setSelectedOs("Linux")
+    }
+  }, [])
 
   const selectOs = (os: OsType) => {
     setSelectedOs(os)


### PR DESCRIPTION
## 内容

#231 を修正します。

## 関連 Issue

- closes: #231

## スクリーンショット・動画など

（なし）

## その他

Windows -> CPU -> Linuxみたいな順にクリックしたときの挙動がホンの少し変わりますがまぁそんなことをする人はめったにいないので大丈夫かと