### PR TITLE
add: Nemo用のデフォルトエンジンの更新情報を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ curl -s "$editor_url/public/updateInfos.json" \
 cp public/updateInfos.json src/data/updateInfos.json  # 0.22までsrc/dataディレクトリだったので、しばらくはコピーする
 
 # デフォルトエンジンの更新情報
-pnpm run generateLatestDefaultEngineInfos
+pnpm run generateLatestDefaultEngineInfos \
+  --github_release_url="https://api.github.com/repos/VOICEVOX/voicevox_engine/releases" \
+  --output_path="public/latestDefaultEngineInfos.json"
+pnpm run generateLatestDefaultEngineInfos \
+  --github_release_url="https://api.github.com/repos/VOICEVOX/voicevox_nemo_engine/releases" \
+  --output_path="public/nemoLatestDefaultEngineInfos.json"
 ```
 
 ## サンプル音声の音量

--- a/public/nemoLatestDefaultEngineInfos.json
+++ b/public/nemoLatestDefaultEngineInfos.json
@@ -1,0 +1,77 @@
+{
+  "formatVersion": 1,
+  "windows": {
+    "x64": {
+      "CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-windows-cpu-0.21.0.vvpp",
+            "name": "voicevox_engine-windows-cpu-0.21.0.vvpp",
+            "size": 137877002
+          }
+        ]
+      },
+      "GPU/CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-windows-directml-0.21.0.vvpp",
+            "name": "voicevox_engine-windows-directml-0.21.0.vvpp",
+            "size": 146047296
+          }
+        ]
+      }
+    }
+  },
+  "macos": {
+    "x64": {
+      "CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-macos-x64-0.21.0.vvpp",
+            "name": "voicevox_engine-macos-x64-0.21.0.vvpp",
+            "size": 145585609
+          }
+        ]
+      }
+    },
+    "arm64": {
+      "CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-macos-arm64-0.21.0.vvpp",
+            "name": "voicevox_engine-macos-arm64-0.21.0.vvpp",
+            "size": 137740236
+          }
+        ]
+      }
+    }
+  },
+  "linux": {
+    "x64": {
+      "CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-linux-cpu-0.21.0.vvpp",
+            "name": "voicevox_engine-linux-cpu-0.21.0.vvpp",
+            "size": 160960098
+          }
+        ]
+      },
+      "GPU/CPU": {
+        "version": "0.21.0",
+        "packages": [
+          {
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-linux-nvidia-0.21.0.vvpp",
+            "name": "voicevox_engine-linux-nvidia-0.21.0.vvpp",
+            "size": 1398947786
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/tools/generateLatestDefaultEngineInfos.ts
+++ b/src/tools/generateLatestDefaultEngineInfos.ts
@@ -66,15 +66,17 @@ import z from "zod";
 
 const args = parseArgs({
   options: {
-    output_path: {
-      type: "string",
-      default: "public/latestDefaultEngineInfos.json",
-    },
+    github_release_url: { type: "string" },
+    output_path: { type: "string" },
   },
 }).values;
 
-const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/VOICEVOX/voicevox_engine/releases";
+if (args.github_release_url == undefined) {
+  throw new Error("github_release_urlが指定されていません");
+}
+if (args.output_path == undefined) {
+  throw new Error("output_pathが指定されていません");
+}
 
 /** 対応するvvpp.txtの名前 */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -122,7 +124,7 @@ let releases = z
     ),
   })
   .array()
-  .parse(await (await fetch(GITHUB_RELEASES_URL)).json());
+  .parse(await (await fetch(args.github_release_url)).json());
 
 // draftとprereleaseを除外
 releases = releases.filter((release) => !release.draft && !release.prerelease);


### PR DESCRIPTION
## 内容

エディタ側のテストに必要になったので作ってみました。
（特にデフォルトエンジンとしてNemoを搭載する予定はありません。）

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2444

## その他

`latest default engine info`という名前にしてるけど、普通に`latest engine info`という名前でもいいかも･･･？
デフォルトエンジンを前提とすべきか否か･･･。
