### PR TITLE
fix: Google Analyticsのバグを修正

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -55,11 +55,9 @@ const imageUrl = _image
   : undefined;
 const hasImage = imageUrl != undefined && imageAlt != undefined;
 
-// Google Analytics。実際のページ以外では読み込まない。
-const googleAnalyticsSrc =
-  isDevelopment || isPreview || isTest
-    ? undefined
-    : `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`;
+// Google Analytics。実際のページ以外ではデバッグモードにする。
+const isGoogleAnalyticsDebugMode = isDevelopment || isPreview || isTest;
+const googleAnalyticsSrc = `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`;
 ---
 
 <html lang="ja" transition:animate="none" data-theme="light">
@@ -107,15 +105,25 @@ const googleAnalyticsSrc =
 
     {/* Google Analytics */}
     <script is:inline src={googleAnalyticsSrc}></script>
-    <script is:inline define:vars={{ GA_TRACKING_ID }}>
+    <script
+      is:inline
+      define:vars={{ GA_TRACKING_ID, isGoogleAnalyticsDebugMode }}
+    >
       window.dataLayer = window.dataLayer || [];
-      window.gtag = function gtag(...args) {
-        dataLayer.push(args);
+      window.gtag = function gtag() {
+        dataLayer.push(arguments);
       };
       document.addEventListener("astro:page-load", () => {
         if ((navigator.doNotTrack || window.doNotTrack) != "1") {
           gtag("js", new Date());
-          gtag("config", GA_TRACKING_ID);
+          gtag("config", GA_TRACKING_ID, {
+            debug_mode: isGoogleAnalyticsDebugMode,
+            send_page_view: false,
+          });
+          gtag("event", "page_view", {
+            page_title: document.title,
+            page_location: location.href,
+          });
         }
       });
     </script>


### PR DESCRIPTION
## 内容

GA4がしばらく動いてない状態になってしまっていたので直します。
argmentsを渡さないとgoogle analyticsがちゃんと動いてくれないらしいことに気づいてませんでした･･･。

## その他

GA4のデバッグ方法のメモ。

Google Analytics内の`DebugView`に表示されるものがたぶん正義。
`debug_mode: true`をconfigで指定すればOK。

Google Analytics内に`debug_mode: true`のフィルタがあるので有効にしておく。
これを使っててもDebugViewには表示されるはず。

`astro:page-load`でconfigを設定した場合、SPA的な遷移はpage viewにカウントされない。
自分で`page_view`イベントを送る。

`/collect`にnetwork送信が発生しているかどうかでデバッグできる。
開発ツールのnetworkで`collect`でフィルタするとわかりやすい。

Astroの`define:vars`とかも普通に使える。
partytownも再度試したけどなんか動かなかった。`window.gtag`をforwardすれば良さそうな気配は感じる。