### PR TITLE
build: Nemoのバージョンを0.23.0に

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pnpm run preview-build
 ```bash
 EDITOR_VERSION="0.23.0"
 RESOURCE_VERSION="0.23.0"
-NEMO_VERSION="0.21.0"
+NEMO_VERSION="0.23.0"
 
 pnpm run updateVersion \
   --editor_version="$EDITOR_VERSION" \

--- a/public/latestDefaultEngineInfos.json
+++ b/public/latestDefaultEngineInfos.json
@@ -3,22 +3,22 @@
   "windows": {
     "x64": {
       "CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-windows-cpu-0.22.2.vvpp",
-            "name": "voicevox_engine-windows-cpu-0.22.2.vvpp",
-            "size": 1500801923
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-windows-cpu-0.23.0.vvpp",
+            "name": "voicevox_engine-windows-cpu-0.23.0.vvpp",
+            "size": 1498695339
           }
         ]
       },
       "GPU/CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-windows-directml-0.22.2.vvpp",
-            "name": "voicevox_engine-windows-directml-0.22.2.vvpp",
-            "size": 1508971782
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-windows-directml-0.23.0.vvpp",
+            "name": "voicevox_engine-windows-directml-0.23.0.vvpp",
+            "size": 1506865198
           }
         ]
       }
@@ -27,24 +27,24 @@
   "macos": {
     "x64": {
       "CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-macos-x64-0.22.2.vvpp",
-            "name": "voicevox_engine-macos-x64-0.22.2.vvpp",
-            "size": 1508236396
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-macos-x64-0.23.0.vvpp",
+            "name": "voicevox_engine-macos-x64-0.23.0.vvpp",
+            "size": 1509522834
           }
         ]
       }
     },
     "arm64": {
       "CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-macos-arm64-0.22.2.vvpp",
-            "name": "voicevox_engine-macos-arm64-0.22.2.vvpp",
-            "size": 1500400706
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-macos-arm64-0.23.0.vvpp",
+            "name": "voicevox_engine-macos-arm64-0.23.0.vvpp",
+            "size": 1492813284
           }
         ]
       }
@@ -53,27 +53,27 @@
   "linux": {
     "x64": {
       "CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-linux-cpu-0.22.2.vvpp",
-            "name": "voicevox_engine-linux-cpu-0.22.2.vvpp",
-            "size": 1523662046
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-linux-cpu-x64-0.23.0.vvpp",
+            "name": "voicevox_engine-linux-cpu-x64-0.23.0.vvpp",
+            "size": 1522686310
           }
         ]
       },
       "GPU/CPU": {
-        "version": "0.22.2",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-linux-nvidia-0.22.2.001.vvppp",
-            "name": "voicevox_engine-linux-nvidia-0.22.2.001.vvppp",
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-linux-nvidia-0.23.0.001.vvppp",
+            "name": "voicevox_engine-linux-nvidia-0.23.0.001.vvppp",
             "size": 1992294400
           },
           {
-            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.22.2/voicevox_engine-linux-nvidia-0.22.2.002.vvppp",
-            "name": "voicevox_engine-linux-nvidia-0.22.2.002.vvppp",
-            "size": 769355334
+            "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.23.0/voicevox_engine-linux-nvidia-0.23.0.002.vvppp",
+            "name": "voicevox_engine-linux-nvidia-0.23.0.002.vvppp",
+            "size": 768379598
           }
         ]
       }

--- a/public/nemoLatestDefaultEngineInfos.json
+++ b/public/nemoLatestDefaultEngineInfos.json
@@ -3,22 +3,22 @@
   "windows": {
     "x64": {
       "CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-windows-cpu-0.21.0.vvpp",
-            "name": "voicevox_engine-windows-cpu-0.21.0.vvpp",
-            "size": 137877002
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-windows-cpu-0.23.0.vvpp",
+            "name": "voicevox_engine-windows-cpu-0.23.0.vvpp",
+            "size": 135912274
           }
         ]
       },
       "GPU/CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-windows-directml-0.21.0.vvpp",
-            "name": "voicevox_engine-windows-directml-0.21.0.vvpp",
-            "size": 146047296
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-windows-directml-0.23.0.vvpp",
+            "name": "voicevox_engine-windows-directml-0.23.0.vvpp",
+            "size": 144082552
           }
         ]
       }
@@ -27,24 +27,24 @@
   "macos": {
     "x64": {
       "CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-macos-x64-0.21.0.vvpp",
-            "name": "voicevox_engine-macos-x64-0.21.0.vvpp",
-            "size": 145585609
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-macos-x64-0.23.0.vvpp",
+            "name": "voicevox_engine-macos-x64-0.23.0.vvpp",
+            "size": 146734278
           }
         ]
       }
     },
     "arm64": {
       "CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-macos-arm64-0.21.0.vvpp",
-            "name": "voicevox_engine-macos-arm64-0.21.0.vvpp",
-            "size": 137740236
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-macos-arm64-0.23.0.vvpp",
+            "name": "voicevox_engine-macos-arm64-0.23.0.vvpp",
+            "size": 130026825
           }
         ]
       }
@@ -53,22 +53,22 @@
   "linux": {
     "x64": {
       "CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-linux-cpu-0.21.0.vvpp",
-            "name": "voicevox_engine-linux-cpu-0.21.0.vvpp",
-            "size": 160960098
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-linux-cpu-x64-0.23.0.vvpp",
+            "name": "voicevox_engine-linux-cpu-x64-0.23.0.vvpp",
+            "size": 159898813
           }
         ]
       },
       "GPU/CPU": {
-        "version": "0.21.0",
+        "version": "0.23.0",
         "packages": [
           {
-            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.21.0/voicevox_engine-linux-nvidia-0.21.0.vvpp",
-            "name": "voicevox_engine-linux-nvidia-0.21.0.vvpp",
-            "size": 1398947786
+            "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.23.0/voicevox_engine-linux-nvidia-0.23.0.vvpp",
+            "name": "voicevox_engine-linux-nvidia-0.23.0.vvpp",
+            "size": 1397886501
           }
         ]
       }

--- a/src/components/modal/download/DownloadNemoModal.tsx
+++ b/src/components/modal/download/DownloadNemoModal.tsx
@@ -8,12 +8,18 @@ import { useStore } from "@nanostores/react";
 import { useEffect, useState } from "react";
 
 type OsType = "Windows" | "Mac" | "Linux";
-type ModeType = "GPU / CPU" | "CPU" | "CPU (Intel)" | "CPU (Apple)";
+type ModeType =
+  | "GPU / CPU"
+  | "CPU"
+  | "CPU (Intel)"
+  | "CPU (Apple)"
+  | "CPU (x64)"
+  | "CPU (arm64)";
 
 const modeAvailables: Record<OsType, ModeType[]> = {
   Windows: ["GPU / CPU", "CPU"],
   Mac: ["CPU (Intel)", "CPU (Apple)"],
-  Linux: ["GPU / CPU", "CPU"],
+  Linux: ["GPU / CPU", "CPU (x64)", "CPU (arm64)"],
 };
 
 export default function DownloadNemoModal() {
@@ -49,9 +55,13 @@ export default function DownloadNemoModal() {
         url: `https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/${NEMO_VERSION}/voicevox_engine-linux-nvidia-${NEMO_VERSION}.vvpp`,
         name: `VOICEVOX.Nemo.${NEMO_VERSION}.Linux.vvpp`,
       },
-      CPU: {
-        url: `https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/${NEMO_VERSION}/voicevox_engine-linux-cpu-${NEMO_VERSION}.vvpp`,
+      "CPU (x64)": {
+        url: `https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/${NEMO_VERSION}/voicevox_engine-linux-cpu-x64-${NEMO_VERSION}.vvpp`,
         name: `VOICEVOX-CPU.Nemo.${NEMO_VERSION}.Linux.vvpp`,
+      },
+      "CPU (arm64)": {
+        url: `https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/${NEMO_VERSION}/voicevox_engine-linux-cpu-arm64-${NEMO_VERSION}.vvpp`,
+        name: `VOICEVOX-CPU-arm64.Nemo.${NEMO_VERSION}.Linux.vvpp`,
       },
     },
   };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
 export const APP_VERSION = "0.23.0";
-export const NEMO_VERSION = "0.21.0";
+export const NEMO_VERSION = "0.23.0";
 
 export const GA_TRACKING_ID = "G-NZL33X0EQV";

--- a/src/tools/generateLatestDefaultEngineInfos.ts
+++ b/src/tools/generateLatestDefaultEngineInfos.ts
@@ -98,7 +98,7 @@ function getVvppTxtName(version: string): any {
     },
     linux: {
       x64: {
-        CPU: `voicevox_engine-linux-cpu-${version}.vvpp.txt`,
+        CPU: `voicevox_engine-linux-cpu-x64-${version}.vvpp.txt`,
         "GPU/CPU": `voicevox_engine-linux-nvidia-${version}.vvpp.txt`,
       },
     },


### PR DESCRIPTION
## 内容

Nemoのバージョンも0.23.0に上げて、arm64版vvppをダウンロード可能にします。

## その他
