### PR TITLE
feat!: 製品ページで選んだキャラクターが即座に中央に表示するようにし、テストも追加

### DIFF
--- a/src/pages/product/[characterId].astro
+++ b/src/pages/product/[characterId].astro
@@ -157,7 +157,7 @@ const characterBackgroundColor = characterInfo.lightColor;
         </div>
       </div>
       <div class="charamenu container">
-        <div class="characters">
+        <div class="characters" aria-label="キャラクター一覧">
           {
             characterKeys.map((key) => (
               <a
@@ -166,6 +166,7 @@ const characterBackgroundColor = characterInfo.lightColor;
                 aria-label={characterInfos[key].name}
                 role="button"
                 style={{
+                  // FIXME: astro の define:vars で渡す
                   "--characterLightColor": characterInfos[key].lightColor,
                   "--characterColor": characterInfos[key].color,
                 }}
@@ -218,38 +219,26 @@ const characterBackgroundColor = characterInfo.lightColor;
 </Base>
 
 <script is:inline>
-  const initScroll = () => {
-    const charamenu = document.querySelector(".charamenu > .characters");
-    if (charamenu) {
-      const active = charamenu.querySelector(".active");
-      if (active) {
-        const activeCenter = active.offsetLeft + active.offsetWidth / 2;
-        const containerCenter = charamenu.offsetWidth / 2;
-        charamenu.scrollLeft = activeCenter - containerCenter;
-      }
-    }
-  };
-  let scrollPos = 0;
+  function scrollToCenter() {
+    const characterList = document.querySelector(
+      "[aria-label='キャラクター一覧']",
+    );
+    if (characterList == undefined) return;
 
-  const beforeSwapListener = (event) => {
-    const charamenu = event.target.querySelector(".charamenu > .characters");
-    if (charamenu) {
-      scrollPos = charamenu.scrollLeft;
-      document.addEventListener("astro:after-swap", afterSwapListener);
-    }
-    document.removeEventListener("astro:before-swap", beforeSwapListener);
-  };
-  const afterSwapListener = (event) => {
-    const charamenu = event.target.querySelector(".charamenu > .characters");
-    if (charamenu) {
-      if (scrollPos > 0) charamenu.scrollLeft = scrollPos;
-      document.addEventListener("astro:before-swap", beforeSwapListener);
-    }
-    document.removeEventListener("astro:after-swap", afterSwapListener);
-  };
-  document.addEventListener("astro:before-swap", beforeSwapListener);
+    if (!(characterList instanceof HTMLElement))
+      throw new Error(`characterList is not HTMLElement: ${characterList}`);
 
-  initScroll();
+    const active = characterList.querySelector(".active");
+    if (!(active instanceof HTMLElement))
+      throw new Error(`active is not HTMLElement: ${active}`);
+
+    const activeCenter = active.offsetLeft + active.offsetWidth / 2;
+    const containerCenter = characterList.offsetWidth / 2;
+    characterList.scrollLeft = activeCenter - containerCenter;
+  }
+  document.addEventListener("astro:after-swap", scrollToCenter);
+
+  scrollToCenter();
 </script>
 
 <style lang="scss" define:vars={{ characterBackgroundColor }} is:global>
@@ -388,14 +377,14 @@ const characterBackgroundColor = characterInfo.lightColor;
     .charamenu {
       position: relative;
       display: flex;
-      height: 5rem;
+      height: 5rem; // FIXME: `top`クラスとの空中配線を解消する
       @include mobile {
-        position: absolute;
+        position: absolute; // FIXME: absoluteを使わない方法にする
         top: calc(100vh - 5rem);
         left: 0;
         width: 100%;
         height: 5rem;
-        z-index: 1;
+        z-index: 1; // FIXME: z-indexを使わない方法にする
 
         .characters {
           padding: 0 1rem;

--- a/tests/e2e/ui/product.spec.ts
+++ b/tests/e2e/ui/product.spec.ts
@@ -1,0 +1,41 @@
+import { gotoAndWait } from "../helper";
+import { characterEntries, characterKeys } from "@/constants/characterEntry";
+import { getProductPageUrl } from "@/constants/url";
+import { expect, test } from "@playwright/test";
+
+// NOTE: https://github.com/VOICEVOX/voicevox_blog/pull/267#pullrequestreview-2740302454
+test("後ろの方のキャラクターの製品ページに遷移したとき、キャラクターリスト内のそのキャラクターが表示されている", async ({
+  page,
+}) => {
+  const lastCharacterKey = characterKeys[characterKeys.length - 1];
+  const lastCharacterEntry = characterEntries[lastCharacterKey];
+
+  await gotoAndWait(page, getProductPageUrl(lastCharacterEntry));
+
+  const characterList = page.getByLabel("キャラクター一覧");
+  await expect(
+    characterList.getByLabel(lastCharacterEntry.name, { exact: true }),
+  ).toBeInViewport();
+});
+
+test("キャラクターの製品ページでは、そのキャラクターが中央に表示される", async ({
+  page,
+}) => {
+  // 真ん中の方のキャラクターを選択
+  const middleIndex = Math.floor(characterKeys.length / 2);
+  const middleCharacterKey = characterKeys[middleIndex];
+  const middleCharacterEntry = characterEntries[middleCharacterKey];
+
+  // 真ん中のキャラクターのページへ遷移
+  await gotoAndWait(page, getProductPageUrl(middleCharacterEntry));
+
+  // キャラメニューリストのスクロール位置が大体真ん中になっていることを確認
+  const characterList = page.getByLabel("キャラクター一覧");
+  const position = await characterList.evaluate((el) => el.scrollLeft);
+  const scrollWidth = await characterList.evaluate((el) => el.scrollWidth);
+  const clientWidth = await characterList.evaluate((el) => el.clientWidth);
+  const middlePosition = scrollWidth / 2 - clientWidth / 2;
+  const tolerance = clientWidth / 8;
+  expect(position).toBeGreaterThan(middlePosition - tolerance);
+  expect(position).toBeLessThan(middlePosition + tolerance);
+});


### PR DESCRIPTION
## 内容

↓２つのコメントの実装です。

- https://github.com/VOICEVOX/voicevox_blog/pull/267#pullrequestreview-2747336778
- https://github.com/VOICEVOX/voicevox_blog/pull/267#pullrequestreview-2747617380

リストからキャラクターを選んだとき、即座にそのキャラクターのアイコンが中央に移動するようにします。

## その他

結局`<script is:inline>`にしました。。。

ドキュメントのここ↓によると、is:inlineに書いたのは２回以上実行されうるというのと、
（まあこれは単一コンポーネントだから関係ないかも）
https://docs.astro.build/en/guides/client-side-scripts/#opting-out-of-processing

あと実行タイミングがそのスクリプトが読み込まれた時点になるので若干不安定だということもあり、`is:inline`を付けないほうが良いかなぁと思ってました。
（とはいえ実行されるのは必ずDOMが読み込まれたあと･･･なはず）

`<script>`にしたところ、実行されるタイミングが思ってるよりだいぶ遅いことがわかりました 😇 
ちなみに今のastroのバージョンだと、`pnpm start`でやってるときと`pnpm build && pnpm preview`したときだと`<script>`が実行されるタイミングがだいぶ違います。
`preview`時のが圧倒的に速い･･･のですが、それでもwebを低速モードにするとタイミングが微妙でした。。
（画像が読み込まれてから実行される）

公式ページで紹介されてるダークモード切り替えのサンプルは`is:inline`で関数を即座に実行してるし、もうこれで良いかと思いました･･･！！！
https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap