### PR TITLE
refactor(test): テストがわかりやすいようにstepで区切るように

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import js from "@eslint/js";
+import gitignore from "eslint-config-flat-gitignore";
 import prettier from "eslint-config-prettier";
 import astro from "eslint-plugin-astro";
 import typescript from "typescript-eslint";
@@ -9,6 +10,7 @@ export default typescript.config(
   prettier,
   astro.configs["flat/recommended"],
   astro.configs["flat/jsx-a11y-recommended"],
+  gitignore(),
   {
     ignores: ["src/layouts/Base.astro"], // なぜか<html>周りでエラーが出る
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "bulma": "^1.0.3",
     "cross-env": "^7.0.3",
     "eslint": "^9.24.0",
+    "eslint-config-flat-gitignore": "^2.1.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-astro": "^1.3.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       eslint:
         specifier: ^9.24.0
         version: 9.24.0
+      eslint-config-flat-gitignore:
+        specifier: ^2.1.0
+        version: 2.1.0(eslint@9.24.0)
       eslint-config-prettier:
         specifier: ^10.1.1
         version: 10.1.1(eslint@9.24.0)
@@ -477,6 +480,15 @@ packages:
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/compat@1.2.8':
+    resolution: {integrity: sha512-LqCYHdWL/QqKIJuZ/ucMAv8d4luKGs4oCPgpt8mWztQAtPrHfXKQ/XAUc8ljCHAfJCn6SvkpTcGt5Tsh8saowA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.10.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/config-array@0.20.0':
     resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
@@ -1647,6 +1659,11 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       eslint: '>=6.0.0'
+
+  eslint-config-flat-gitignore@2.1.0:
+    resolution: {integrity: sha512-cJzNJ7L+psWp5mXM7jBX+fjHtBvvh06RBlcweMhKD8jWqQw0G78hOW5tpVALGHGFPsBV+ot2H+pdDGJy6CV8pA==}
+    peerDependencies:
+      eslint: ^9.5.0
 
   eslint-config-prettier@10.1.1:
     resolution: {integrity: sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==}
@@ -3788,6 +3805,10 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
+  '@eslint/compat@1.2.8(eslint@9.24.0)':
+    optionalDependencies:
+      eslint: 9.24.0
+
   '@eslint/config-array@0.20.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
@@ -5090,6 +5111,11 @@ snapshots:
     dependencies:
       eslint: 9.24.0
       semver: 7.7.1
+
+  eslint-config-flat-gitignore@2.1.0(eslint@9.24.0):
+    dependencies:
+      '@eslint/compat': 1.2.8(eslint@9.24.0)
+      eslint: 9.24.0
 
   eslint-config-prettier@10.1.1(eslint@9.24.0):
     dependencies:

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -1,5 +1,3 @@
-import type { Page } from "playwright/test";
-
 export const isDevelopment = import.meta.env?.DEV == true;
 export const isProduction = import.meta.env?.PROD == true;
 export const isPreview = import.meta.env?.PREVIEW == true;
@@ -204,21 +202,4 @@ export function sendEvent(event: string, eventCategory: string) {
   if (typeof window !== "undefined" && window.gtag) {
     window.gtag("event", event, { event_category: eventCategory });
   }
-}
-
-/** Playwright内で画像の読み込みが完了するまで待つ */
-export async function waitForImages(page: Page) {
-  await page.waitForFunction(() =>
-    Array.from(document.images).every((img) => img.complete),
-  );
-}
-
-/** Playwright内で音声の読み込みが完了するまで待つ */
-export async function waitForAudios(page: Page) {
-  // 読み込み中クラスがあるボタンが存在しないことを確認する
-  await page.waitForFunction(() =>
-    Array.from(document.querySelectorAll(".is-loading")).every(
-      (element) => !(element instanceof HTMLButtonElement),
-    ),
-  );
 }

--- a/src/helper/playwrightHelper.ts
+++ b/src/helper/playwrightHelper.ts
@@ -1,0 +1,22 @@
+import { test, type Page } from "playwright/test";
+
+/** Playwright内で画像の読み込みが完了するまで待つ */
+export async function waitForImages(page: Page) {
+  await test.step("画像の読み込みが完了するまで待つ", async () => {
+    await page.waitForFunction(() =>
+      Array.from(document.images).every((img) => img.complete),
+    );
+  });
+}
+
+/** Playwright内で音声の読み込みが完了するまで待つ */
+export async function waitForAudios(page: Page) {
+  await test.step("音声の読み込みが完了するまで待つ", async () => {
+    // 読み込み中クラスがあるボタンが存在しないことを確認する
+    await page.waitForFunction(() =>
+      Array.from(document.querySelectorAll(".is-loading")).every(
+        (element) => !(element instanceof HTMLButtonElement),
+      ),
+    );
+  });
+}

--- a/src/tools/generateThumb.mts
+++ b/src/tools/generateThumb.mts
@@ -2,7 +2,7 @@
  * サムネイル画像を生成する
  */
 import { characterKeys, characterEntries } from "@/constants/characterEntry";
-import { waitForImages } from "@/helper";
+import { waitForImages } from "@/helper/playwrightHelper";
 import fs from "fs";
 import path from "path";
 import { chromium } from "playwright";

--- a/tests/e2e/helper.ts
+++ b/tests/e2e/helper.ts
@@ -1,14 +1,15 @@
-import { waitForAudios, waitForImages } from "@/helper";
-import { expect, type Page } from "playwright/test";
+import { waitForAudios, waitForImages } from "@/helper/playwrightHelper";
+import { expect, type Page, test } from "playwright/test";
 
-/** ページを読み込んで少し待つ */
 export async function gotoAndWait(
   page: Page,
   url: string,
   timeout: number = 10,
 ) {
-  await page.goto(url);
-  await page.waitForTimeout(timeout);
+  await test.step("ページを読み込んで少し待つ", async () => {
+    await page.goto(url);
+    await page.waitForTimeout(timeout);
+  });
 }
 
 /** 一番下まで少しずつスクロールする */
@@ -16,27 +17,30 @@ export async function progressiveScroll(
   page: Page,
   callback?: () => Promise<void>,
 ) {
-  let isAtBottom = false;
-  for (let i = 0; i < 50; i++) {
-    await callback?.();
+  await test.step("一番下まで少しずつスクロールする", async () => {
+    let isAtBottom = false;
+    for (let i = 0; i < 50; i++) {
+      await callback?.();
 
-    const currentPosition = await page.evaluate(() => window.scrollY);
-    await page.evaluate(() => window.scrollBy(0, window.innerHeight - 100)); // 100pxだけオーバーラップさせる
-    const newPosition = await page.evaluate(() => window.scrollY);
-    if (currentPosition === newPosition) {
-      isAtBottom = true;
-      break;
+      const currentPosition = await page.evaluate(() => window.scrollY);
+      await page.evaluate(() => window.scrollBy(0, window.innerHeight - 100)); // 100pxだけオーバーラップさせる
+      const newPosition = await page.evaluate(() => window.scrollY);
+      if (currentPosition === newPosition) {
+        isAtBottom = true;
+        break;
+      }
     }
-  }
-  expect(isAtBottom).toBeTruthy();
+    expect(isAtBottom).toBeTruthy();
+  });
 }
 
-/** 最初に全部表示してリソースを読み込んでトップに戻る */
 export async function preparePage(page: Page) {
-  await progressiveScroll(page, async () => {
-    await page.waitForTimeout(10); // 画像の読み込みリクエストが走るのを待つ
+  await test.step("最初に全部表示してリソースを読み込んでトップに戻る", async () => {
+    await progressiveScroll(page, async () => {
+      await page.waitForTimeout(10); // 画像の読み込みリクエストが走るのを待つ
+    });
+    await waitForImages(page);
+    await waitForAudios(page);
+    await page.evaluate(() => window.scrollTo(0, 0));
   });
-  await waitForImages(page);
-  await waitForAudios(page);
-  await page.evaluate(() => window.scrollTo(0, 0));
 }

--- a/tests/e2e/meta/index.spec.ts
+++ b/tests/e2e/meta/index.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import fs from "node:fs";
-import { buffer } from "node:stream/consumers";
 import path from "node:path";
+import { buffer } from "node:stream/consumers";
 
 const sitemapPath = path.join(
   import.meta.dirname,
@@ -18,39 +18,43 @@ test.describe("http meta", () => {
     test(pathname, async ({ baseURL }) => {
       const http = await fetch(baseURL + pathname).then((res) => res.text());
 
-      // メタ情報のテスト
-      const metaInfo = {} as Record<string, string | undefined>;
+      await test.step("メタ情報のテスト", async () => {
+        const metaInfo = {} as Record<string, string | undefined>;
 
-      metaInfo.canonicalUrl = http.match(
-        /<link rel="canonical" href="(.*?)"/,
-      )?.[1];
+        metaInfo.canonicalUrl = http.match(
+          /<link rel="canonical" href="(.*?)"/,
+        )?.[1];
 
-      metaInfo.title = http.match(/<title>(.*?)<\/title>/)?.[1];
+        metaInfo.title = http.match(/<title>(.*?)<\/title>/)?.[1];
 
-      metaInfo.description = http.match(
-        /<meta name="description" content="(.*?)"/,
-      )?.[1];
+        metaInfo.description = http.match(
+          /<meta name="description" content="(.*?)"/,
+        )?.[1];
 
-      metaInfo.robots = http.match(/<meta name="robots" content="(.*?)"/)?.[1];
+        metaInfo.robots = http.match(
+          /<meta name="robots" content="(.*?)"/,
+        )?.[1];
 
-      expect(JSON.stringify(metaInfo, null, 2)).toMatchSnapshot();
+        expect(JSON.stringify(metaInfo, null, 2)).toMatchSnapshot();
+      });
 
-      // og:imageのテスト
-      const ogImageUrl = http.match(
-        /<meta property="og:image" content="(.*?)"/,
-      )?.[1];
-      if (ogImageUrl != undefined) {
-        // 相対パスになっているものとURLになっているものがあるので両方に対応
-        const ogImagePathname = ogImageUrl.startsWith("/")
-          ? ogImageUrl
-          : new URL(ogImageUrl).pathname;
-        const ogImage = await fetch(baseURL + ogImagePathname)
-          .then((res) => res.body)
-          .then((body) => buffer(body!));
-        expect(ogImage).toMatchSnapshot(
-          `share${pathname.replaceAll("/", "-")}.webp`,
-        );
-      }
+      await test.step("og:imageのテスト", async () => {
+        const ogImageUrl = http.match(
+          /<meta property="og:image" content="(.*?)"/,
+        )?.[1];
+        if (ogImageUrl != undefined) {
+          // 相対パスになっているものとURLになっているものがあるので両方に対応
+          const ogImagePathname = ogImageUrl.startsWith("/")
+            ? ogImageUrl
+            : new URL(ogImageUrl).pathname;
+          const ogImage = await fetch(baseURL + ogImagePathname)
+            .then((res) => res.body)
+            .then((body) => buffer(body!));
+          expect(ogImage).toMatchSnapshot(
+            `share${pathname.replaceAll("/", "-")}.webp`,
+          );
+        }
+      });
     });
   }
 });

--- a/tests/e2e/screenshot/helper.ts
+++ b/tests/e2e/screenshot/helper.ts
@@ -1,12 +1,13 @@
-import { expect, type Page } from "playwright/test";
 import { preparePage, progressiveScroll } from "../helper";
+import test, { expect, type Page } from "playwright/test";
 
-/** スクリーンショットを撮ってスクロールしてを繰り返す */
 export async function takeScreenshots(page: Page) {
-  await preparePage(page);
+  await test.step("スクリーンショットを撮ってスクロールしてを繰り返す", async () => {
+    await preparePage(page);
 
-  // 最初からスクリーンショットを撮っていく
-  await progressiveScroll(page, async () => {
-    await expect(page).toHaveScreenshot();
+    // 最初からスクリーンショットを撮っていく
+    await progressiveScroll(page, async () => {
+      await expect(page).toHaveScreenshot();
+    });
   });
 }

--- a/tests/e2e/ui/nemo.spec.ts
+++ b/tests/e2e/ui/nemo.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
-import { getLocators, isMobile } from "./helper";
 import { gotoAndWait } from "../helper";
+import { getLocators, isMobile } from "./helper";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   await gotoAndWait(page, "/nemo/");
@@ -9,54 +9,67 @@ test.beforeEach(async ({ page }) => {
 test("ダウンロードボタン", async ({ page }) => {
   const { header, modal } = getLocators(page);
 
-  // ファーストビューのダウンロードボタンでモーダルが表示される
-  const downloadButton = page.getByTestId("first-view").getByRole("button", {
-    name: "ダウンロード",
+  await test.step("ファーストビューのダウンロードボタンでモーダルが表示される", async () => {
+    const downloadButton = page.getByTestId("first-view").getByRole("button", {
+      name: "ダウンロード",
+    });
+    await downloadButton.scrollIntoViewIfNeeded();
+    await downloadButton.click();
+    await expect(modal).toContainText("VOICEVOX Nemo ご利用案内");
   });
-  await downloadButton.scrollIntoViewIfNeeded();
-  await downloadButton.click();
-  await expect(modal).toContainText("VOICEVOX Nemo ご利用案内");
 
-  // ヘッダーのダウンロードボタンでモーダルが表示される
-  await page.getByRole("button", { name: "close" }).click();
-  if (isMobile(page)) await header.getByLabel("menu").click();
-  const headerDownloadButton = header.getByRole("button", {
-    name: "ダウンロード",
+  await test.step("モーダルを閉じれる", async () => {
+    await page.getByRole("button", { name: "close" }).click();
+    await expect(modal).toHaveCount(0);
   });
-  await headerDownloadButton.click();
-  await expect(modal).toContainText("VOICEVOX Nemo ご利用案内");
 
-  // モーダルの表示状態を確認
-  await expect(page).toHaveScreenshot();
+  await test.step("ヘッダーのダウンロードボタンで１つ目のモーダルが表示される", async () => {
+    if (isMobile(page)) await header.getByLabel("menu").click();
+    const headerDownloadButton = header.getByRole("button", {
+      name: "ダウンロード",
+    });
+    await headerDownloadButton.click();
+    await expect(modal).toContainText("VOICEVOX Nemo ご利用案内");
+    await expect(page).toHaveScreenshot();
+  });
 
-  await modal
-    .getByRole("button", { name: "VOICEVOX ダウンロード", exact: true })
-    .click();
-  await expect(modal).toHaveCount(2); // モーダルが２つ開かれてる
-  await expect(page).toHaveScreenshot();
+  await test.step("モーダル内のVOICEVOXダウンロードボタンで２つ目のモーダルが表示される", async () => {
+    await modal
+      .getByRole("button", { name: "VOICEVOX ダウンロード", exact: true })
+      .click();
+    await expect(modal).toHaveCount(2);
+    await expect(page).toHaveScreenshot();
+  });
 
-  await modal
-    .locator("header")
-    .filter({ hasText: "VOICEVOX ダウンロード" })
-    .getByLabel("close")
-    .click();
-  await expect(modal).toHaveCount(1);
+  await test.step("２つ目のモーダルを閉じれる", async () => {
+    await modal
+      .locator("header")
+      .filter({ hasText: "VOICEVOX ダウンロード" })
+      .getByLabel("close")
+      .click();
+    await expect(modal).toHaveCount(1);
+  });
 
-  await modal
-    .getByRole("button", { name: "Nemo エンジン ダウンロード", exact: true })
-    .click();
-  await expect(modal).toHaveCount(2); // モーダルが２つ開かれてる
-  await expect(page).toHaveScreenshot();
+  await test.step("モーダル内のNemoエンジンダウンロードボタンで２つ目のモーダルが表示される", async () => {
+    await modal
+      .getByRole("button", { name: "Nemo エンジン ダウンロード", exact: true })
+      .click();
+    await expect(modal).toHaveCount(2);
+    await expect(page).toHaveScreenshot();
+  });
 });
 
 test("利用規約", async ({ page }) => {
   const { modal } = getLocators(page);
 
-  // 利用規約モーダルを表示できる
-  await page.getByRole("button", { name: "利用規約", exact: true }).click();
-  await expect(page).toHaveScreenshot();
+  await test.step("利用規約モーダルを表示できる", async () => {
+    await page.getByRole("button", { name: "利用規約", exact: true }).click();
+    await expect(modal).toHaveCount(1);
+    await expect(page).toHaveScreenshot();
+  });
 
-  // 利用規約を表示できる
-  await modal.getByRole("link", { name: "利用規約", exact: true }).click();
-  await expect(page).toHaveURL("/nemo/term/");
+  await test.step("利用規約を表示できる", async () => {
+    await modal.getByRole("link", { name: "利用規約", exact: true }).click();
+    await expect(page).toHaveURL("/nemo/term/");
+  });
 });

--- a/tests/e2e/ui/product.spec.ts
+++ b/tests/e2e/ui/product.spec.ts
@@ -21,21 +21,21 @@ test("後ろの方のキャラクターの製品ページに遷移したとき�
 test("キャラクターの製品ページでは、そのキャラクターが中央に表示される", async ({
   page,
 }) => {
-  // 真ん中の方のキャラクターを選択
-  const middleIndex = Math.floor(characterKeys.length / 2);
-  const middleCharacterKey = characterKeys[middleIndex];
-  const middleCharacterEntry = characterEntries[middleCharacterKey];
+  await test.step("真ん中のキャラクターのページへ遷移", async () => {
+    const middleIndex = Math.floor(characterKeys.length / 2);
+    const middleCharacterKey = characterKeys[middleIndex];
+    const middleCharacterEntry = characterEntries[middleCharacterKey];
+    await gotoAndWait(page, getProductPageUrl(middleCharacterEntry));
+  });
 
-  // 真ん中のキャラクターのページへ遷移
-  await gotoAndWait(page, getProductPageUrl(middleCharacterEntry));
-
-  // キャラメニューリストのスクロール位置が大体真ん中になっていることを確認
-  const characterList = page.getByLabel("キャラクター一覧");
-  const position = await characterList.evaluate((el) => el.scrollLeft);
-  const scrollWidth = await characterList.evaluate((el) => el.scrollWidth);
-  const clientWidth = await characterList.evaluate((el) => el.clientWidth);
-  const middlePosition = scrollWidth / 2 - clientWidth / 2;
-  const tolerance = clientWidth / 8;
-  expect(position).toBeGreaterThan(middlePosition - tolerance);
-  expect(position).toBeLessThan(middlePosition + tolerance);
+  await test.step("キャラメニューリストのスクロール位置が大体真ん中になっている", async () => {
+    const characterList = page.getByLabel("キャラクター一覧");
+    const position = await characterList.evaluate((el) => el.scrollLeft);
+    const scrollWidth = await characterList.evaluate((el) => el.scrollWidth);
+    const clientWidth = await characterList.evaluate((el) => el.clientWidth);
+    const middlePosition = scrollWidth / 2 - clientWidth / 2;
+    const tolerance = clientWidth / 8;
+    expect(position).toBeGreaterThan(middlePosition - tolerance);
+    expect(position).toBeLessThan(middlePosition + tolerance);
+  });
 });

--- a/tests/e2e/ui/song.spec.ts
+++ b/tests/e2e/ui/song.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
-import { getLocators, isMobile } from "./helper";
 import { gotoAndWait } from "../helper";
+import { getLocators, isMobile } from "./helper";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   await gotoAndWait(page, "/song/");
@@ -9,20 +9,25 @@ test.beforeEach(async ({ page }) => {
 test("ダウンロードボタン", async ({ page }) => {
   const { header, modal } = getLocators(page);
 
-  // ファーストビューのダウンロードボタンでモーダルが表示される
-  const downloadButton = page.getByTestId("first-view").getByRole("button", {
-    name: "ダウンロード",
+  await test.step("ファーストビューのダウンロードボタンでモーダルが表示される", async () => {
+    const downloadButton = page.getByTestId("first-view").getByRole("button", {
+      name: "ダウンロード",
+    });
+    await downloadButton.scrollIntoViewIfNeeded();
+    await downloadButton.click();
+    await expect(modal).toContainText("VOICEVOX ダウンロード");
   });
-  await downloadButton.scrollIntoViewIfNeeded();
-  await downloadButton.click();
-  await expect(modal).toContainText("VOICEVOX ダウンロード");
 
-  // ヘッダーのダウンロードボタンでモーダルが表示される
-  await page.getByRole("button", { name: "close" }).click();
-  if (isMobile(page)) await header.getByLabel("menu").click();
-  const headerDownloadButton = header.getByRole("button", {
-    name: "ダウンロード",
+  await test.step("モーダルを閉じれる", async () => {
+    await page.getByRole("button", { name: "close" }).click();
   });
-  await headerDownloadButton.click();
-  await expect(modal).toContainText("VOICEVOX ダウンロード");
+
+  await test.step("ヘッダーのダウンロードボタンでモーダルが表示される", async () => {
+    if (isMobile(page)) await header.getByLabel("menu").click();
+    const headerDownloadButton = header.getByRole("button", {
+      name: "ダウンロード",
+    });
+    await headerDownloadButton.click();
+    await expect(modal).toContainText("VOICEVOX ダウンロード");
+  });
 });

--- a/tests/e2e/ui/talk.spec.ts
+++ b/tests/e2e/ui/talk.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
-import { getLocators, isMobile } from "./helper";
 import { gotoAndWait, preparePage } from "../helper";
+import { getLocators, isMobile } from "./helper";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   await gotoAndWait(page, "/");
@@ -9,90 +9,111 @@ test.beforeEach(async ({ page }) => {
 test("ヘッダー", async ({ page }) => {
   const { header } = getLocators(page);
 
-  // 最初はヘッダーが表示されていない
-  await expect(header).not.toBeVisible();
+  await test.step("最初はヘッダーが表示されていない", async () => {
+    await expect(header).not.toBeVisible();
+  });
 
-  // 少しスクロールするとヘッダーが表示される
-  await page.evaluate(() => window.scrollBy(0, 500));
-  await expect(header).toBeVisible();
+  await test.step("少しスクロールするとヘッダーが表示される", async () => {
+    await page.evaluate(() => window.scrollBy(0, 500));
+    await expect(header).toBeVisible();
+  });
 
-  // トップに戻るとヘッダーが非表示になる
-  await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(header).not.toBeVisible();
+  await test.step("トップに戻るとヘッダーが非表示になる", async () => {
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(header).not.toBeVisible();
+  });
 });
 
 test("ダウンロードボタン", async ({ page }) => {
   const { header, modal } = getLocators(page);
 
-  // ファーストビューのダウンロードボタンでモーダルが表示される
-  const downloadButton = page.getByTestId("first-view").getByRole("button", {
-    name: "ダウンロード",
+  await test.step("ファーストビューのダウンロードボタンでモーダルが表示される", async () => {
+    const downloadButton = page.getByTestId("first-view").getByRole("button", {
+      name: "ダウンロード",
+    });
+    await downloadButton.scrollIntoViewIfNeeded();
+    await downloadButton.click();
+    await expect(modal).toContainText("VOICEVOX ダウンロード");
   });
-  await downloadButton.scrollIntoViewIfNeeded();
-  await downloadButton.click();
-  await expect(modal).toContainText("VOICEVOX ダウンロード");
 
-  // ヘッダーのダウンロードボタンでモーダルが表示される
-  await page.getByRole("button", { name: "close" }).click();
-  await page.evaluate(() => window.scrollBy(0, 500));
-  if (isMobile(page)) await header.getByLabel("menu").click();
-  const headerDownloadButton = header.getByRole("button", {
-    name: "ダウンロード",
+  await test.step("モーダルを閉じれる", async () => {
+    await page.getByRole("button", { name: "close" }).click();
   });
-  await headerDownloadButton.click();
-  await expect(modal).toContainText("VOICEVOX ダウンロード");
 
-  // モーダルの表示状態を確認
-  await expect(page).toHaveScreenshot();
+  await test.step("ヘッダーのダウンロードボタンでモーダルが表示される", async () => {
+    await page.evaluate(() => window.scrollBy(0, 500));
+    if (isMobile(page)) await header.getByLabel("menu").click();
+    const headerDownloadButton = header.getByRole("button", {
+      name: "ダウンロード",
+    });
+    await headerDownloadButton.click();
+    await expect(modal).toContainText("VOICEVOX ダウンロード");
+  });
 
-  await modal.getByRole("button", { name: "Mac" }).click();
-  await expect(page).toHaveScreenshot();
+  await test.step("モーダルの表示状態を確認", async () => {
+    await expect(page).toHaveScreenshot();
 
-  await modal.getByRole("button", { name: "Linux" }).click();
-  await expect(page).toHaveScreenshot();
+    await modal.getByRole("button", { name: "Mac" }).click();
+    await expect(page).toHaveScreenshot();
 
-  // 利用規約に飛べる
-  await modal.getByRole("button", { name: "利用規約", exact: true }).click();
-  await expect(page).toHaveURL("/term/");
+    await modal.getByRole("button", { name: "Linux" }).click();
+    await expect(page).toHaveScreenshot();
+  });
+
+  await test.step("利用規約に飛べる", async () => {
+    await modal.getByRole("button", { name: "利用規約", exact: true }).click();
+    await expect(page).toHaveURL("/term/");
+  });
 });
 
 test.describe("キャラクターカード", () => {
   test("スタイル", async ({ page }) => {
     await preparePage(page);
-    const styleChangeButton = page.getByLabel(
-      "ずんだもんのサンプルボイスのスタイルを選択",
-    );
-    await styleChangeButton.scrollIntoViewIfNeeded();
 
-    // スタイルを変更できる
-    await expect(styleChangeButton).toContainText("ノーマル");
-    await styleChangeButton.click();
-    await expect(page).toHaveScreenshot();
-    await page.getByRole("menu").getByText("ささやき").click();
-    await expect(styleChangeButton).toContainText("ささやき");
-    await styleChangeButton.click();
-    await expect(page).toHaveScreenshot();
+    await test.step("スタイルを変更できる", async () => {
+      const styleChangeButton = page.getByLabel(
+        "ずんだもんのサンプルボイスのスタイルを選択",
+      );
+      await styleChangeButton.scrollIntoViewIfNeeded();
+
+      await expect(styleChangeButton).toContainText("ノーマル");
+      await styleChangeButton.click();
+      await expect(page).toHaveScreenshot();
+      await page.getByRole("menu").getByText("ささやき").click();
+      await expect(styleChangeButton).toContainText("ささやき");
+      await styleChangeButton.click();
+      await expect(page).toHaveScreenshot();
+    });
   });
 
   test("利用規約", async ({ page }) => {
     const { modal } = getLocators(page);
     await preparePage(page);
 
-    // 利用規約モーダルを表示できる
-    await page
-      .getByText("ずんだもん", { exact: true })
-      .scrollIntoViewIfNeeded();
-    await page.getByRole("button", { name: "ずんだもん 利用規約" }).click();
-    await expect(modal.locator("header")).toContainText("ずんだもん 利用規約");
-    await expect(page).toHaveScreenshot();
+    await test.step("利用規約モーダルを表示できる", async () => {
+      await page
+        .getByText("ずんだもん", { exact: true })
+        .scrollIntoViewIfNeeded();
+      await page.getByRole("button", { name: "ずんだもん 利用規約" }).click();
+      await expect(modal.locator("header")).toContainText(
+        "ずんだもん 利用規約",
+      );
+      await expect(page).toHaveScreenshot();
+    });
 
-    // 別のキャラクターの利用規約も表示できる
-    await page.getByRole("button", { name: "close" }).click();
-    await page
-      .getByText("冥鳴ひまり", { exact: true })
-      .scrollIntoViewIfNeeded();
-    await page.getByRole("button", { name: "冥鳴ひまり 利用規約" }).click();
-    await expect(modal.locator("header")).toContainText("冥鳴ひまり 利用規約");
-    await expect(page).toHaveScreenshot();
+    await test.step("モーダルを閉じれる", async () => {
+      await page.getByRole("button", { name: "close" }).click();
+    });
+
+    await test.step("別のキャラクターの利用規約も表示できる", async () => {
+      await page
+        .getByText("冥鳴ひまり", { exact: true })
+        .scrollIntoViewIfNeeded();
+      await page.getByRole("button", { name: "冥鳴ひまり 利用規約" }).click();
+      await expect(modal.locator("header")).toContainText(
+        "冥鳴ひまり 利用規約",
+      );
+      await expect(page).toHaveScreenshot();
+    });
   });
 });


### PR DESCRIPTION
## 内容

テストがわかりやすいようにstepで区切るようにしました。
これでe2eテストを実行して落ちた時も分かりやすいし、実際に作る時もどこまで進んだかが日本語で表示されるので分かりやすいはず。

## その他
