### PR TITLE
fix: songタイトルのハイライトの不透明度を調整

### DIFF
--- a/src/pages/song/index.astro
+++ b/src/pages/song/index.astro
@@ -203,7 +203,7 @@ const backgroundImageUrl = `url(${(await getImage({ src: backgroundImage })).src
           text-shadow: 0 0 10px
             rgb(
               from color-mix(in srgb, var(--bulma-link-text) 95%, black) R G B /
-                0.85
+                0.55
             );
         }
 


### PR DESCRIPTION
## 概要

songタイトルのtext-shadowの不透明度を0.85から0.55に下げ、ハイライトの眩しさを抑えました。

close #303