### PR TITLE
feat: defaultEngineInfosに表示情報を追加

### DIFF
--- a/public/latestDefaultEngineInfos.json
+++ b/public/latestDefaultEngineInfos.json
@@ -3,6 +3,11 @@
   "packages": {
     "windows-x64-cpu": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-windows-cpu-0.25.1.vvpp",
@@ -13,6 +18,12 @@
     },
     "windows-x64-directml": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "GPU / CPU両対応版",
+        "hint": "DirectML対応のGPUが必要です",
+        "order": 1,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-windows-directml-0.25.1.vvpp",
@@ -23,6 +34,12 @@
     },
     "macos-x64-cpu": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-macos-x64-0.25.1.vvpp",
@@ -33,6 +50,12 @@
     },
     "macos-arm64-cpu": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-macos-arm64-0.25.1.vvpp",
@@ -43,6 +66,12 @@
     },
     "linux-x64-cpu": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-linux-cpu-x64-0.25.1.vvpp",
@@ -53,6 +82,11 @@
     },
     "linux-x64-cuda": {
       "version": "0.25.1",
+      "displayInfo": {
+        "label": "CUDA版",
+        "hint": "CUDA対応のNVIDIA製GPUが必要です",
+        "order": 1
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_engine/releases/download/0.25.1/voicevox_engine-linux-nvidia-0.25.1.001.vvppp",

--- a/public/latestDefaultEngineInfos.json
+++ b/public/latestDefaultEngineInfos.json
@@ -4,8 +4,8 @@
     "windows-x64-cpu": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0
       },
       "files": [
@@ -19,8 +19,8 @@
     "windows-x64-directml": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "GPU / CPU両対応版",
-        "hint": "DirectML対応のGPUが必要です",
+        "label": "GPU / CPU",
+        "hint": "DirectML対応のGPUでも音声を生成できます",
         "order": 1,
         "default": true
       },
@@ -35,8 +35,8 @@
     "macos-x64-cpu": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -51,8 +51,8 @@
     "macos-arm64-cpu": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -67,8 +67,8 @@
     "linux-x64-cpu": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -83,8 +83,8 @@
     "linux-x64-cuda": {
       "version": "0.25.1",
       "displayInfo": {
-        "label": "CUDA版",
-        "hint": "CUDA対応のNVIDIA製GPUが必要です",
+        "label": "GPU(CUDA)",
+        "hint": "CUDA対応のNVIDIA製GPUでも音声を生成できます",
         "order": 1
       },
       "files": [

--- a/public/nemoLatestDefaultEngineInfos.json
+++ b/public/nemoLatestDefaultEngineInfos.json
@@ -3,6 +3,11 @@
   "packages": {
     "windows-x64-cpu": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-windows-cpu-0.24.0.vvpp",
@@ -13,6 +18,12 @@
     },
     "windows-x64-directml": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "GPU / CPU両対応版",
+        "hint": "DirectML対応のGPUが必要です",
+        "order": 1,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-windows-directml-0.24.0.vvpp",
@@ -23,6 +34,12 @@
     },
     "macos-x64-cpu": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-macos-x64-0.24.0.vvpp",
@@ -33,6 +50,12 @@
     },
     "macos-arm64-cpu": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-macos-arm64-0.24.0.vvpp",
@@ -43,6 +66,12 @@
     },
     "linux-x64-cpu": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "CPU版",
+        "hint": "CPUで動作します",
+        "order": 0,
+        "default": true
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-linux-cpu-x64-0.24.0.vvpp",
@@ -53,6 +82,11 @@
     },
     "linux-x64-cuda": {
       "version": "0.24.0",
+      "displayInfo": {
+        "label": "CUDA版",
+        "hint": "CUDA対応のNVIDIA製GPUが必要です",
+        "order": 1
+      },
       "files": [
         {
           "url": "https://github.com/VOICEVOX/voicevox_nemo_engine/releases/download/0.24.0/voicevox_engine-linux-nvidia-0.24.0.vvpp",

--- a/public/nemoLatestDefaultEngineInfos.json
+++ b/public/nemoLatestDefaultEngineInfos.json
@@ -4,8 +4,8 @@
     "windows-x64-cpu": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0
       },
       "files": [
@@ -19,8 +19,8 @@
     "windows-x64-directml": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "GPU / CPU両対応版",
-        "hint": "DirectML対応のGPUが必要です",
+        "label": "GPU / CPU",
+        "hint": "DirectML対応のGPUでも音声を生成できます",
         "order": 1,
         "default": true
       },
@@ -35,8 +35,8 @@
     "macos-x64-cpu": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -51,8 +51,8 @@
     "macos-arm64-cpu": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -67,8 +67,8 @@
     "linux-x64-cpu": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "CPU版",
-        "hint": "CPUで動作します",
+        "label": "CPU",
+        "hint": "CPUで音声を生成します",
         "order": 0,
         "default": true
       },
@@ -83,8 +83,8 @@
     "linux-x64-cuda": {
       "version": "0.24.0",
       "displayInfo": {
-        "label": "CUDA版",
-        "hint": "CUDA対応のNVIDIA製GPUが必要です",
+        "label": "GPU(CUDA)",
+        "hint": "CUDA対応のNVIDIA製GPUでも音声を生成できます",
         "order": 1
       },
       "files": [

--- a/src/tools/generateLatestDefaultEngineInfos.ts
+++ b/src/tools/generateLatestDefaultEngineInfos.ts
@@ -57,14 +57,13 @@ jsonファイルの形式は以下の通り。
     "linux-x64-cuda": {}
   }
 }
+```
 
 displayInfoの仕様
 - label: 「対応モード」として案内される表示名
 - hint: ラベルの説明文として案内される表示名
 - order: 各OS/アーキテクチャごとに0から始まる連続した数値
 - default: 各OS/アーキテクチャごとにtrueのものが1つだけ存在
-```
-
 */
 import fs from "fs";
 import semver from "semver";

--- a/src/tools/generateLatestDefaultEngineInfos.ts
+++ b/src/tools/generateLatestDefaultEngineInfos.ts
@@ -29,7 +29,7 @@ jsonファイルの形式は以下の通り。
         "order": 0,
 
         //[boolean(Optional)] デフォルトとして選択するか
-        "default": true,
+        "default": true
       },
 
       // vvppやvvpppの情報

--- a/src/tools/generateLatestDefaultEngineInfos.ts
+++ b/src/tools/generateLatestDefaultEngineInfos.ts
@@ -23,7 +23,7 @@ jsonファイルの形式は以下の通り。
         "label": "CPU版",
 
         //[string] ヒント
-        "hint": "CPUで動作します",
+        "hint": "CPUで音声を生成します",
 
         //[number] 表示順序
         "order": 0,
@@ -104,15 +104,15 @@ const runtimeTargets: RuntimeTarget[] = [
     os: "windows",
     arch: "x64",
     device: "cpu",
-    displayInfo: { label: "CPU版", hint: "CPUで動作します", order: 0 },
+    displayInfo: { label: "CPU", hint: "CPUで音声を生成します", order: 0 },
   },
   {
     os: "windows",
     arch: "x64",
     device: "directml",
     displayInfo: {
-      label: "GPU / CPU両対応版",
-      hint: "DirectML対応のGPUが必要です",
+      label: "GPU / CPU",
+      hint: "DirectML対応のGPUでも音声を生成できます",
       order: 1,
       default: true,
     },
@@ -122,8 +122,8 @@ const runtimeTargets: RuntimeTarget[] = [
     arch: "x64",
     device: "cpu",
     displayInfo: {
-      label: "CPU版",
-      hint: "CPUで動作します",
+      label: "CPU",
+      hint: "CPUで音声を生成します",
       order: 0,
       default: true,
     },
@@ -133,8 +133,8 @@ const runtimeTargets: RuntimeTarget[] = [
     arch: "arm64",
     device: "cpu",
     displayInfo: {
-      label: "CPU版",
-      hint: "CPUで動作します",
+      label: "CPU",
+      hint: "CPUで音声を生成します",
       order: 0,
       default: true,
     },
@@ -144,8 +144,8 @@ const runtimeTargets: RuntimeTarget[] = [
     arch: "x64",
     device: "cpu",
     displayInfo: {
-      label: "CPU版",
-      hint: "CPUで動作します",
+      label: "CPU",
+      hint: "CPUで音声を生成します",
       order: 0,
       default: true,
     },
@@ -155,8 +155,8 @@ const runtimeTargets: RuntimeTarget[] = [
     arch: "x64",
     device: "cuda",
     displayInfo: {
-      label: "CUDA版",
-      hint: "CUDA対応のNVIDIA製GPUが必要です",
+      label: "GPU(CUDA)",
+      hint: "CUDA対応のNVIDIA製GPUでも音声を生成できます",
       order: 1,
     },
   },


### PR DESCRIPTION
## 内容

`generateLatestDefaultEngineInfos.ts` に `displayInfo` フィールドの出力を追加して、現状の VOICEVOX/voicevox#2866 のWelcome画面機能に対応してみました。

## 関連 Issue

ref VOICEVOX/voicevox#2866

## その他

ラベルの中身めっちゃ迷ったけど一旦この形にしました。
スレッドコメントで解説してみてます 🙇 