### PR TITLE
feat: pinactでGitHub ActionsをSHAにピン留めする

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -6,12 +6,12 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         run_install: false
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: ".node-version"
         cache: "pnpm"

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      uses: pnpm/action-setup@v4
       with:
         run_install: false
 

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         run_install: false
 

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/actions/*/action.yml"
+
+ignore_actions:
+  - name: VOICEVOX/preview-pages/base
+    ref: main
+  - name: voicevox/merge-gatekeeper
+    ref: main

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -21,7 +21,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload static files as artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: dist/
 
@@ -37,4 +37,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/build_preview_pages.yml
+++ b/.github/workflows/build_preview_pages.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -32,7 +32,7 @@ jobs:
           pnpm run build --base ${{ steps.determine_base_url.outputs.base_url }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: preview-pages
           path: "./dist"

--- a/.github/workflows/merge_gatekeeper.yml
+++ b/.github/workflows/merge_gatekeeper.yml
@@ -21,7 +21,7 @@ jobs:
           score_rules: |
             #maintainer: 2
             #reviewer: 1
-      - uses: upsidr/merge-gatekeeper@v1
+      - uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           self: merge_gatekeeper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Check typos
+        uses: crate-ci/typos@47912c390ab44028f45fe2abc0bb5c6d97392bf8 # v1.12.12
+
       - name: Check pinact
         uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
         with:
@@ -112,14 +115,6 @@ jobs:
         with:
           name: updated-snapshots-windows-latest
           path: patch-windows-latest.diff
-
-  typos:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: typos-action
-        uses: crate-ci/typos@47912c390ab44028f45fe2abc0bb5c6d97392bf8 # v1.12.12
 
   commit_snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
         with:
           skip_push: "true"
+          min_age: "7"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -44,11 +44,16 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Check pinact
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          skip_push: "true"
+
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -61,7 +66,7 @@ jobs:
     needs: [config]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -85,7 +90,7 @@ jobs:
 
       - name: Upload playwright report to artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report
@@ -102,7 +107,7 @@ jobs:
 
       - name: Upload patch to artifact
         if: needs.config.outputs.shouldUpdateSnapshots == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: updated-snapshots-windows-latest
           path: patch-windows-latest.diff
@@ -110,10 +115,10 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: typos-action
-        uses: crate-ci/typos@v1.12.12
+        uses: crate-ci/typos@47912c390ab44028f45fe2abc0bb5c6d97392bf8 # v1.12.12
 
   commit_snapshots:
     runs-on: ubuntu-latest
@@ -122,7 +127,7 @@ jobs:
     needs: [config, e2e]
     if: needs.config.outputs.shouldUpdateSnapshots == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # NOTE: デフォルトの設定だとgithub-push-actionが動いてくれないので設定を変えている。
           # ref: https://github.com/ad-m/github-push-action/issues/44#issuecomment-581706892
@@ -130,7 +135,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: updated-snapshots-*
           path: ${{ runner.temp }}/patches
@@ -168,7 +173,7 @@ jobs:
 
       - name: Show warning if token is not set
         if: steps.commit-updated-snapshots.outputs.changes_exist == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const pushTokenProvided = `${{ secrets.PUSH_TOKEN }}` !== "";

--- a/README.md
+++ b/README.md
@@ -146,10 +146,20 @@ pnpm run fmt
 pnpm run lint
 ```
 
+### GitHub Actions のバージョン固定
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
+プルリクエストを送ると自動でテストされます。
+
+```bash
+# 固定する
+pinact run
+```
+
 ### タイポチェック
 
-[typos](https://github.com/crate-ci/typos) を使ってタイポのチェックを行っています。  
-ブランチをプッシュすると自動でテストされます。
+[typos](https://github.com/crate-ci/typos) を使ってタイポのチェックを行っています。
+プルリクエストを送ると自動でテストされます。
 
 ### e2e テスト
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ pnpm run lint
 プルリクエストを送ると自動でテストされます。
 
 ```bash
+# バージョンを固定する
+pinact run
+
 # バージョンを更新して固定する
 pinact run --update --min-age 7
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ pinact run --update --min-age 7
 
 ### タイポチェック
 
-[typos](https://github.com/crate-ci/typos) を使ってタイポのチェックを行っています。
+[typos](https://github.com/crate-ci/typos) を使ってタイポのチェックを行っています。  
 プルリクエストを送ると自動でテストされます。
 
 ### e2e テスト

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ pnpm run lint
 プルリクエストを送ると自動でテストされます。
 
 ```bash
-# 固定する
-pinact run
+# バージョンを更新して固定する
+pinact run --update --min-age 7
 ```
 
 ### タイポチェック


### PR DESCRIPTION
## 内容

[pinact](https://github.com/suzuki-shunsuke/pinact) を使って、GitHub Actionsのバージョン指定をタグ（`@v4`等）からfull-length commit SHAに変換しました。
また、PRのたびにpinactで検証するCIステップを追加しました。

## 関連 Issue

ref VOICEVOX/voicevox_project#82

## その他

`.github/pinact.yaml` に2点の設定が必要でした。

- `files`: pinactのデフォルトスキャン対象は `.github/workflows/*.yml` のみで、`.github/actions/*/action.yml`（composite action）が含まれないため、明示的に追加しています。
- `ignore_actions`: `VOICEVOX/preview-pages/base@main` と `voicevox/merge-gatekeeper@main` はブランチ参照のためSHAに変換できず、設定なしではエラーになるため除外しています。

なお `pnpm/action-setup@v4` は `v4` タグがv5系のコミットに移動していたため、正しいv4系最新（`v4.4.0`）に修正しました。