### PR TITLE
fix: スマホでヘッダーが見え隠れして振動する問題を解決できるかも

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## コマンド
 
-`README.md`
+`README.md`を読んでください。
 
 ## コーディング規約
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## コマンド
 
-`README.md`
+`README.md`を読んでください。
 
 ## コーディング規約
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -272,10 +272,7 @@ export default function Header({
       </Collapsible.Root>
 
       {/* 空間を空けるために必要 */}
-      {/* NOTE: defaultHideページではスペーサーのレイアウトシフトがIntersectionObserverと振動するため除外 */}
-      {!defaultHide && (
-        <div className={`h-13 ${showingHeader ? "" : "hidden"} invisible`} />
-      )}
+      <div className={`invisible h-13 ${defaultHide ? "hidden" : ""}`} />
     </>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -272,7 +272,10 @@ export default function Header({
       </Collapsible.Root>
 
       {/* 空間を空けるために必要 */}
-      <div className={`h-13 ${showingHeader ? "" : "hidden"} invisible`} />
+      {/* MEMO: defaultHideページではスペーサーのレイアウトシフトがIntersectionObserverと振動するため除外 */}
+      {!defaultHide && (
+        <div className={`h-13 ${showingHeader ? "" : "hidden"} invisible`} />
+      )}
     </>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -272,7 +272,7 @@ export default function Header({
       </Collapsible.Root>
 
       {/* 空間を空けるために必要 */}
-      {/* MEMO: defaultHideページではスペーサーのレイアウトシフトがIntersectionObserverと振動するため除外 */}
+      {/* NOTE: defaultHideページではスペーサーのレイアウトシフトがIntersectionObserverと振動するため除外 */}
       {!defaultHide && (
         <div className={`h-13 ${showingHeader ? "" : "hidden"} invisible`} />
       )}


### PR DESCRIPTION
## 内容

defaultHideページでのスペーサーのレイアウトシフトを修正してみました。
これで効くかは不明。
