### PR TITLE
fix: newsページをsitemapから除外

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
-      filter: (page) => !page.includes("/dev/"),
+      filter: (page) => !page.includes("/dev/") && !page.includes("/news/"),
     }),
     react(),
     /*

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -18,7 +18,7 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { article } = Astro.props;
 const { frontmatter } = article;
 
-// TODO: リリース時にnoindexを外す
+// TODO: リリース時にnoindexを外す。併せて astro.config.ts の sitemap filter からも /news/ を外す
 ---
 
 <Base

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -9,7 +9,7 @@ import Base from "@/layouts/Base.astro";
 import shareThumb from "./_share.jpg";
 import { articles } from "./constants";
 
-// TODO: リリース時にnoindexを外す
+// TODO: リリース時にnoindexを外す。併せて astro.config.ts の sitemap filter からも /news/ を外す
 ---
 
 <Base

--- a/tests/e2e/sitemap/index.spec.ts-snapshots/sitemap-0-Desktop-Chrome-win32.xml
+++ b/tests/e2e/sitemap/index.spec.ts-snapshots/sitemap-0-Desktop-Chrome-win32.xml
@@ -482,21 +482,6 @@
     </url>
     <url>
         <loc>
-            https://voicevox.hiroshiba.jp/news/
-        </loc>
-    </url>
-    <url>
-        <loc>
-            https://voicevox.hiroshiba.jp/news/fuga/
-        </loc>
-    </url>
-    <url>
-        <loc>
-            https://voicevox.hiroshiba.jp/news/hoge/
-        </loc>
-    </url>
-    <url>
-        <loc>
             https://voicevox.hiroshiba.jp/product/aierutan/
         </loc>
     </url>


### PR DESCRIPTION
## 内容

未公開のnewsページが本番のsitemapに含まれてしまっていたので、`astro.config.ts` の sitemap filter に `/news/` の除外を追加しました。ページ自体は `noindex` 付きで引き続きデプロイされますが、sitemapには現れなくなります。

併せて、news側のTODOコメントに「リリース時は sitemap filter からも `/news/` を外す」旨を追記しました。

## 関連 Issue

close #357

## スクリーンショット・動画など

なし

## その他

なし