### PR TITLE
fix(ci): フォント読み込み待機を修正

### DIFF
--- a/src/helper/playwrightHelper.ts
+++ b/src/helper/playwrightHelper.ts
@@ -94,16 +94,12 @@ export async function waitForAudios(page: Page) {
 
 /** ページ内のフォントがすべて読み込まれるまで待機する */
 export async function waitForFonts(page: Page) {
-  const fontEvaluateCallback = () => {
-    return {
-      total: 1,
-      completeCount: document.fonts.status === "loaded" ? 1 : 0,
-    };
+  const executor = async () => {
+    await page.evaluate(() => document.fonts.ready);
   };
 
-  await waitForResourcesWithTimeout(
-    page,
-    fontEvaluateCallback,
+  await executeWithStepRecording(
     "フォントの読み込みが完了するまで待つ",
+    executor,
   );
 }


### PR DESCRIPTION
## 内容

`waitForFonts` が5秒で抜けることがあったので、`document.fonts.ready` を待つようにしました。

## 関連 Issue

- #359
