### PR TITLE
docs: Playwright locator の書き方をコーディング規約に追記する

### DIFF
--- a/docs/コーディング規約.md
+++ b/docs/コーディング規約.md
@@ -34,8 +34,20 @@
   - カスタムトークンは `global.css` で定義されている
 - grayは使わない、neutral を使う
 
+## Playwright
+
+- showcase・VRT のためだけに存在する引数には `debug` プレフィックスを付ける
+- locator はユーザーから見える意味で取得できるものを優先する
+  - 適切な locator が書けない場合は、ソースコードの変更を検討する
+  - `getByRole` を優先する
+  - 次に `getByLabel`・`getByText`・`getByPlaceholder`・`getByAltText`・`getByTitle` などから対象を自然に表せるものを使う
+  - コンポーネント名の CSS クラス、あるいはコンポーネント名とパーツ名を組み合わせた CSS クラスは使ってよい
+  - ここまでの方法で難しい場合は `data-testid` を使う
+  - DOM 構造に依存するセレクターは原則使わない
+
 ## その他
 
+- WCAG に準拠する
 - インポートした画像等は定数(constants)として良い
 - CSS in JS は使わない
   - 理由は単によく知らないから
@@ -53,7 +65,6 @@
 - Radixにするかどうかは、大事なユースケースに属するかどうかで判断する
   - 例えばただのセパレータくらいなら別にRadixにしなくても良い
 - Radix Themesは使わない
-- showcase・VRT のためだけに存在する引数には `debug` プレフィックスを付ける
 - ボタン系のhoverは`vv-status-layer`クラスを使う
 - focusはブラウザのデフォルトの挙動を使い、特別なスタイルを作らない
 - z-indexはどうしても必要な場合以外使わず、DOMツリーの構造で重なり順を制御する


### PR DESCRIPTION
## 内容

E2E テストで Playwright の `locator` の書き方に迷わないよう、選択方針をコーディング規約に追記します。

ref VOICEVOX/voicevox#3043

## その他

VOICEVOX/voicevoxの方でskill作ったので、それ試してからマージ予定です。
