### PR TITLE
fix: aria-label を日本語にして E2E テストの locator を更新する

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -245,7 +245,7 @@ export default function Header({
               <Collapsible.Trigger asChild>
                 <button
                   className={`${menuTriggerClassName} lg:hidden`}
-                  aria-label="menu"
+                  aria-label="メニュー"
                   type="button"
                 >
                   <span aria-hidden="true" className="text-xl leading-none">

--- a/src/components/modal/ModalShell.tsx
+++ b/src/components/modal/ModalShell.tsx
@@ -43,7 +43,7 @@ export default function ModalShell({
                 <IconButton
                   size="sm"
                   className="text-neutral-700"
-                  aria-label="close"
+                  aria-label="閉じる"
                 >
                   <span aria-hidden="true" className="text-xl leading-none">
                     <FontAwesomeIcon icon={faXmark} />

--- a/tests/e2e/ui/nemo.spec.ts
+++ b/tests/e2e/ui/nemo.spec.ts
@@ -19,12 +19,12 @@ test("ダウンロードボタン", async ({ page }) => {
   });
 
   await test.step("モーダルを閉じれる", async () => {
-    await page.getByRole("button", { name: "close" }).click();
+    await page.getByRole("button", { name: "閉じる" }).click();
     await expect(modal).toHaveCount(0);
   });
 
   await test.step("ヘッダーのダウンロードボタンで１つ目のモーダルが表示される", async () => {
-    if (isMobile(page)) await header.getByLabel("menu").click();
+    if (isMobile(page)) await header.getByLabel("メニュー").click();
     const headerDownloadButton = header.getByRole("button", {
       name: "ダウンロード",
     });
@@ -42,7 +42,7 @@ test("ダウンロードボタン", async ({ page }) => {
   });
 
   await test.step("２つ目のモーダルを閉じれる", async () => {
-    await modal.getByLabel("close").click();
+    await modal.getByLabel("閉じる").click();
     await expect(modal).toContainText("VOICEVOX Nemo ご利用案内");
   });
 

--- a/tests/e2e/ui/song.spec.ts
+++ b/tests/e2e/ui/song.spec.ts
@@ -19,11 +19,11 @@ test("ダウンロードボタン", async ({ page }) => {
   });
 
   await test.step("モーダルを閉じれる", async () => {
-    await page.getByRole("button", { name: "close" }).click();
+    await page.getByRole("button", { name: "閉じる" }).click();
   });
 
   await test.step("ヘッダーのダウンロードボタンでモーダルが表示される", async () => {
-    if (isMobile(page)) await header.getByLabel("menu").click();
+    if (isMobile(page)) await header.getByLabel("メニュー").click();
     const headerDownloadButton = header.getByRole("button", {
       name: "ダウンロード",
     });

--- a/tests/e2e/ui/talk.spec.ts
+++ b/tests/e2e/ui/talk.spec.ts
@@ -37,12 +37,12 @@ test("ダウンロードボタン", async ({ page }) => {
   });
 
   await test.step("モーダルを閉じれる", async () => {
-    await page.getByRole("button", { name: "close" }).click();
+    await page.getByRole("button", { name: "閉じる" }).click();
   });
 
   await test.step("ヘッダーのダウンロードボタンでモーダルが表示される", async () => {
     await page.evaluate(() => window.scrollBy(0, 500));
-    if (isMobile(page)) await header.getByLabel("menu").click();
+    if (isMobile(page)) await header.getByLabel("メニュー").click();
     const headerDownloadButton = header.getByRole("button", {
       name: "ダウンロード",
     });
@@ -95,14 +95,14 @@ test.describe("キャラクターカード", () => {
         .getByText("ずんだもん", { exact: true })
         .scrollIntoViewIfNeeded();
       await page.getByRole("button", { name: "ずんだもん 利用規約" }).click();
-      await expect(modal.locator("header")).toContainText(
+      await expect(modal.getByRole("heading")).toContainText(
         "ずんだもん 利用規約",
       );
       await expect(page).toHaveScreenshot();
     });
 
     await test.step("モーダルを閉じれる", async () => {
-      await page.getByRole("button", { name: "close" }).click();
+      await page.getByRole("button", { name: "閉じる" }).click();
     });
 
     await test.step("別のキャラクターの利用規約も表示できる", async () => {
@@ -110,7 +110,7 @@ test.describe("キャラクターカード", () => {
         .getByText("冥鳴ひまり", { exact: true })
         .scrollIntoViewIfNeeded();
       await page.getByRole("button", { name: "冥鳴ひまり 利用規約" }).click();
-      await expect(modal.locator("header")).toContainText(
+      await expect(modal.getByRole("heading")).toContainText(
         "冥鳴ひまり 利用規約",
       );
       await expect(page).toHaveScreenshot();


### PR DESCRIPTION
## 内容

PR #375 で追加された Playwright locator ルールに沿って、既存のテストと実装を修正します。

- `aria-label="close"` → `aria-label="閉じる"`（`ModalShell.tsx`）
- `aria-label="menu"` → `aria-label="メニュー"`（`Header.tsx`）
- テスト側の locator 参照を上記に合わせて更新
- `modal.locator("header")` → `modal.getByRole("heading")` に変更（DOM 構造依存セレクターの排除）

## 関連 Issue

ref #375
