### PR TITLE
fix: preview-pagesのURL生成にデプロイ先を反映する

### DIFF
--- a/.github/workflows/build_preview_pages.yml
+++ b/.github/workflows/build_preview_pages.yml
@@ -28,8 +28,12 @@ jobs:
           name: blog
 
       - name: Build
+        env:
+          PREVIEW: "1"
         run: |
-          pnpm run build --base ${{ steps.determine_base_url.outputs.base_url }}
+          pnpm run build \
+            --site https://voicevox.github.io \
+            --base "${{ steps.determine_base_url.outputs.base_url }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -230,7 +230,11 @@ export function sendEvent(event: string, eventCategory: string) {
 }
 
 /** パスにViteのBASE_URLを追加する関数 */
-export function withBaseUrl(path: string) {
+export function withBaseUrl(path: string): string {
+  if (!path.startsWith("/")) {
+    throw new Error("パスの先頭に/が必要です");
+  }
+
   const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, "");
-  return baseUrl ? `${baseUrl}/${path}` : path;
+  return `${baseUrl}${path}`;
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,6 +13,7 @@ import {
   isPreview,
   isTest,
   stripHtmlTags,
+  withBaseUrl,
 } from "@/helper";
 import "@/styles/global.css";
 import type { ImageMetadata } from "astro";
@@ -100,13 +101,27 @@ const googleAnalyticsSrc = `https://www.googletagmanager.com/gtag/js?id=${GA_TRA
 
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" href={withBaseUrl("/sitemap-index.xml")} />
 
     {/* アイコン */}
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href={withBaseUrl("/apple-touch-icon.png")}
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href={withBaseUrl("/favicon-32x32.png")}
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href={withBaseUrl("/favicon-16x16.png")}
+    />
+    <link rel="manifest" href={withBaseUrl("/site.webmanifest")} />
 
     {/* Google Analytics */}
     <script is:inline async src={googleAnalyticsSrc}></script>

--- a/src/pages/_LinkListSection.astro
+++ b/src/pages/_LinkListSection.astro
@@ -9,10 +9,7 @@ import { isDevelopment, withBaseUrl } from "@/helper";
 <section class="py-3xl">
   <div class="px-md mx-auto flex max-w-5xl flex-col">
     <h2 id="link" class="vv-anchor-offset-4 mb-xl text-3xl font-bold">
-      <a
-        href={withBaseUrl("#link")}
-        class="text-neutral-950 dark:text-neutral-950">リンク</a
-      >
+      <a href="#link" class="text-neutral-950 dark:text-neutral-950">リンク</a>
     </h2>
     <ul class="text-xl">
       <li>

--- a/src/pages/dormitory/[characterId]/[...descriptionType].astro
+++ b/src/pages/dormitory/[characterId]/[...descriptionType].astro
@@ -84,9 +84,7 @@ const backgroundImageUrl = `url(${(await getImage({ src: backgroundImage })).src
                     set:html={characterInfo.rubyName}
                   />
                   <IconButton
-                    href={characterInfo.detailUrl
-                      ? withBaseUrl(characterInfo.detailUrl)
-                      : undefined}
+                    href={characterInfo.detailUrl}
                     size="md"
                     border
                     class:list={[

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,7 +1,7 @@
 /**
  * https://docs.astro.build/ja/guides/integrations-guide/sitemap/#sitemap-link-in-robotstxt からコピー
  */
-import { isPreview } from "@/helper";
+import { isPreview, withBaseUrl } from "@/helper";
 import type { APIRoute } from "astro";
 
 const getRobotsTxt = (sitemapURL: URL) => `User-agent: *
@@ -11,6 +11,6 @@ Sitemap: ${sitemapURL.href}
 `;
 
 export const GET: APIRoute = ({ site }) => {
-  const sitemapURL = new URL("sitemap-index.xml", site);
+  const sitemapURL = new URL(withBaseUrl("/sitemap-index.xml"), site);
   return new Response(getRobotsTxt(sitemapURL));
 };


### PR DESCRIPTION
## 内容

preview-pagesのURL生成に本番環境のオリジンとルートパスが使われ、デプロイ先のURLと一致していません。
その影響でfaviconなどが違うURLを指しています。

デプロイ先のoriginをビルドへ渡すようにしました。

ついでにpreview-pagesでもプレビュー環境用の設定を有効にて、sitemapのignore等が発動するようにしました。
